### PR TITLE
Add DeleteDataLoader

### DIFF
--- a/src/spetlr/cosmos/cosmos_handle.py
+++ b/src/spetlr/cosmos/cosmos_handle.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Union, Any
 
 from pyspark.sql import DataFrame
 from pyspark.sql.types import StructType
@@ -67,3 +67,8 @@ class CosmosHandle(TableHandle):
 
     def get_tablename(self) -> str:
         return self._name
+
+    def delete_data(
+        self, comparison_col: str, comparison_limit: Any, comparison_operator: str
+    ) -> None:
+        raise NotImplementedError("Method not yet implemented in Cosmos")

--- a/src/spetlr/delta/delta_handle.py
+++ b/src/spetlr/delta/delta_handle.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Any
 
 from pyspark.sql import DataFrame
 
@@ -213,3 +213,9 @@ class DeltaHandle(TableHandle):
         print("Incremental Base - incremental load with merge")
 
         return df
+
+    def delete_data(
+        self, comparison_col: str, comparison_limit: Any, comparison_operator: str
+    ) -> None:
+        sql_str = f"DELETE FROM {self._name} WHERE {comparison_col} {comparison_operator} {comparison_limit};"
+        Spark.get().sql(sql_str)

--- a/src/spetlr/etl/loaders/DeleteDataLoader.py
+++ b/src/spetlr/etl/loaders/DeleteDataLoader.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from typing import Any, List, Union
+
+from pyspark.sql import DataFrame
+
+from atc.etl import Loader, dataset_group
+from atc.tables import TableHandle
+
+
+class DeleteDataLoader(Loader):
+    def __init__(
+        self,
+        handle: TableHandle,
+        comparison_col: str,
+        comparison_limit: Any,
+        comparison_operator: str = "<",
+        dataset_input_keys: Union[str, List[str]] = None,
+    ):
+        super().__init__(dataset_input_keys=dataset_input_keys)
+
+        self.handle = handle
+        self.comparison_col = comparison_col
+        self.comparison_limit = comparison_limit
+        self.comparison_operator = comparison_operator
+
+    def save_many(self, datasets: dataset_group) -> None:
+        raise NotImplementedError()
+
+    def save(self, df: DataFrame) -> None:
+        """Delete old data from  a single dataframe to the target table."""
+        self.handle.delete_data(
+            self.comparison_col, self.comparison_limit, self.comparison_operator
+        )

--- a/src/spetlr/sql/sql_handle.py
+++ b/src/spetlr/sql/sql_handle.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Union, Any
 
 from pyspark.sql import DataFrame
 
@@ -77,3 +77,9 @@ class SqlHandle(TableHandle):
 
     def get_tablename(self) -> str:
         return self._name
+
+    def delete_data(
+        self, comparison_col: str, comparison_limit: Any, comparison_operator: str
+    ) -> None:
+        sql_str = f"DELETE FROM {self._name} WHERE {comparison_col} {comparison_operator} {comparison_limit};"
+        self._sql_server.execute_sql(sql_str)

--- a/src/spetlr/tables/TableHandle.py
+++ b/src/spetlr/tables/TableHandle.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List, Union
+from typing import List, Union, Any
 
 from pyspark.sql import DataFrame
 
@@ -30,4 +30,9 @@ class TableHandle(ABC):
         pass
 
     def get_tablename(self) -> str:
+        pass
+
+    def delete_data(
+        self, comparison_col: str, comparison_limit: Any, comparison_operator: str
+    ) -> None:
         pass

--- a/tests/cluster/delta/extras/deletedataloader-test.sql
+++ b/tests/cluster/delta/extras/deletedataloader-test.sql
@@ -1,0 +1,14 @@
+CREATE DATABASE IF NOT EXISTS {DeleteDataLoaderDb}
+COMMENT "Contains Incremental Base test data"
+LOCATION "{DeleteDataLoaderDb_path}";
+
+CREATE TABLE IF NOT EXISTS {DeleteDataLoaderDummy}
+(
+    col1 INTEGER,
+    col2 FLOAT,
+    col3 TIMESTAMP
+    col4 NVARCHAR(255)
+)
+USING DELTA
+COMMENT "Contains DeleteDataLoader Base test data"
+LOCATION "{DeleteDataLoaderDummy_path}"

--- a/tests/cluster/delta/extras/tablenames.yml
+++ b/tests/cluster/delta/extras/tablenames.yml
@@ -24,3 +24,11 @@ UpsertLoaderDb:
 UpsertLoaderDummy:
   name: "{UpsertLoaderDb}.Dummy"
   path: "{UpsertLoaderDb_path}/dummy"
+
+DeleteDataLoaderDb:
+  name: DeleteDataLoader{ID}
+  path: "/tmp/DeleteDataLoader{ID}.db/"
+
+DeleteDataLoaderDummy:
+  name: "{DeleteDataLoaderDb}.Dummy"
+  path: "{DeleteDataLoaderDb_path}/dummy"

--- a/tests/cluster/etl/test_delete_data_loader.py
+++ b/tests/cluster/etl/test_delete_data_loader.py
@@ -1,0 +1,115 @@
+from typing import List
+
+from spetlrtools.testing import DataframeTestCase
+
+from spetlr import Configurator
+from spetlr.delta import DbHandle, DeltaHandle
+from spetlr.etl.loaders.DeleteDataLoader import DeleteDataLoader
+from spetlr.etl.loaders.simple_loader import SimpleLoader
+from spetlr.utils import DataframeCreator
+from tests.cluster.delta import extras
+from tests.cluster.delta.SparkExecutor import SparkSqlExecutor
+
+from datetime import datetime
+
+class UpsertLoaderTests(DataframeTestCase):
+    target_id = "DeleteDataLoaderDummy"
+
+    input_data = [
+        (43, 43.0, "42", datetime(2023, 04, 14, 0, 0, 0)),
+        (42, 42.0, "42", datetime(2023, 04, 13, 0, 0, 0)),
+        (41, 41.0, "42", datetime(2023, 04, 12, 0, 0, 0)),
+        (40, 40.0, "42", datetime(2023, 04, 11, 0, 0, 0)),
+    ]
+
+    data1 = [
+        (43, 43.0, "42", datetime(2023, 04, 14, 0, 0, 0)),
+        (42, 42.0, "42", datetime(2023, 04, 13, 0, 0, 0)),
+        (41, 41.0, "42", datetime(2023, 04, 12, 0, 0, 0)),
+    ]
+
+    data2 = [
+        (42, 42.0, "42", datetime(2023, 04, 13, 0, 0, 0)),
+        (41, 41.0, "42", datetime(2023, 04, 12, 0, 0, 0)),
+    ]
+
+    data3 = [
+        (42, 42.0, "42", datetime(2023, 04, 13, 0, 0, 0)),
+    ]
+
+    data4 = []
+
+    dummy_columns: List[str] = ["col1", "col2", "col3", "col4"]
+
+    dummy_schema = None
+    target_dh_dummy: DeltaHandle = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        Configurator().add_resource_path(extras)
+        Configurator().set_debug()
+
+        cls.target_dh_dummy = DeltaHandle.from_tc("DeleteDataLoaderDummy")
+
+        SparkSqlExecutor().execute_sql_file("deletedataloader-test")
+
+        cls.dummy_schema = cls.target_dh_dummy.read().schema
+
+        # make sure target is empty
+        df_empty = DataframeCreator.make_partial(cls.dummy_schema, [], [])
+        cls.target_dh_dummy.overwrite(df_empty)
+
+        # add specific data
+        cls.target_dh_dummy.write_or_append(
+            DataframeCreator.make_partial(
+                cls.dummy_schema, cls.dummy_columns, cls.data1
+            )
+        )
+        
+    @classmethod
+    def tearDownClass(cls) -> None:
+        DbHandle.from_tc("UpsertLoaderDb").drop_cascade()
+
+    def test_01_can_delete_int_lt(self):
+        loader = DeleteDataLoader(
+            handle=self.target_dh_dummy,
+            comparison_col="col1",
+            comparison_limit=41,
+            comparison_operator="<"    
+        )
+
+        loader.save(None)
+        self.assertDataframeMatches(self.target_dh_dummy.read(), None, self.data1)
+
+    def test_02_can_delete_float_gt(self):
+        loader = DeleteDataLoader(
+            handle=self.target_dh_dummy,
+            comparison_col="col2",
+            comparison_limit=42.0,
+            comparison_operator=">"    
+        )
+
+        loader.save(None)
+        self.assertDataframeMatches(self.target_dh_dummy.read(), None, self.data2)
+
+    def test_03_can_delete_string_eq(self):
+        loader = DeleteDataLoader(
+            handle=self.target_dh_dummy,
+            comparison_col="col3",
+            comparison_limit="42",
+            comparison_operator="="    
+        )
+
+        loader.save(None)
+        self.assertDataframeMatches(self.target_dh_dummy.read(), None, self.data3)
+
+    def test_04_can_delete_timestamp(self):
+        loader = DeleteDataLoader(
+            handle=self.target_dh_dummy,
+            comparison_col="col4",
+            comparison_limit=datetime(2023, 04, 14, 0, 0, 0),
+            comparison_operator="<"    
+        )
+
+        loader.save(None)
+        self.assertDataframeMatches(self.target_dh_dummy.read(), None, self.data4)


### PR DESCRIPTION
This is a Loader designed to be included in ETL flows that deletes data from a given table (currently delta or sql) through a handle.
The Loader is included in ETL flows but does not perform any actions on given dataframes.