### PR TITLE
fix overlap period with empty target

### DIFF
--- a/src/spetlr/etl/extractors/incremental_extractor.py
+++ b/src/spetlr/etl/extractors/incremental_extractor.py
@@ -51,7 +51,7 @@ class IncrementalExtractor(Extractor):
         )
 
         # If overlap_period is defined extract it from target_max_time
-        if self._overlap_period:
+        if self._overlap_period and target_max_time is not None:
             target_max_time = target_max_time - self._overlap_period
 
         # If the target table is empty, target_max_time will be None

--- a/tests/cluster/etl/test_incremental_extractor.py
+++ b/tests/cluster/etl/test_incremental_extractor.py
@@ -252,3 +252,47 @@ class IncrementalExtractorTests(DataframeTestCase):
         df_extract = extractor.read()
 
         self.assertDataframeMatches(df_extract, None, self.extractOverlap)
+
+    def test_05_can_extract_with_overlap_empty_target(self):
+        """
+        Source has the following data:
+        |id| stringcol    | timecol          |
+        |--|--------------|------------------|
+        |2 | "string2"    | 01.01.2021 10:55 |
+        |3|  "string3"    | 01.01.2021 11:00 |
+        |4 | "string4"    | 05.01.2021 11:00 |
+
+        Target has no data:
+
+        |id| stringcol    | timecol          |
+        |--|--------------|------------------|
+        |  |              |                  |
+
+        All data should been read:
+
+        |id| stringcol    | timecol          |
+        |--|--------------|------------------|
+        |2 | "string2"    | 01.01.2021 10:55 |
+        |3|  "string3"    | 01.01.2021 11:00 |
+        |4 | "string4"    | 05.01.2021 11:00 |
+        """
+        source_test_handle = TestHandle(
+            provides=DataframeCreator.make_partial(
+                self.dummy_schema, self.dummy_columns, self.sourceOverlap
+            )
+        )
+        target_test_handle = TestHandle(
+            provides=DataframeCreator.make_partial(
+                self.dummy_schema, self.dummy_columns, []
+            )
+        )
+        extractor = IncrementalExtractor(
+            handle_source=source_test_handle,
+            handle_target=target_test_handle,
+            time_col_source="timecol",
+            time_col_target="timecol",
+            dataset_key="source",
+            overlap_period=timedelta(days=5),
+        )
+        df_extract = extractor.read()
+        self.assertDataframeMatches(df_extract, None, self.extractOverlap)


### PR DESCRIPTION
This PR will fix so overlapping periods in incremental extractors works correctly when the target table is empty.