### PR TITLE
feat: spn cleanup

### DIFF
--- a/.github/deploy/destroy-spns.ps1
+++ b/.github/deploy/destroy-spns.ps1
@@ -1,0 +1,54 @@
+param (
+  [Parameter(Mandatory=$false)]
+  [ValidateNotNullOrEmpty()]
+  [string]
+  $environmentName="",
+
+  [Parameter(Mandatory=$false)]
+  [string]
+  $uniqueRunId
+)
+
+az account show
+
+###############################################################################################
+# Configure names and options
+###############################################################################################
+Write-Host "Initialize deployment" -ForegroundColor Green
+
+# import utility functions
+. "$PSScriptRoot\Utilities\all.ps1"
+
+. "$PSScriptRoot\steps\00-Config.ps1"
+
+
+###############################################################################################
+# Delete spns
+###############################################################################################
+Write-Host "  Now destroying SPN $dbDeploySpnName !" -ForegroundColor Red
+$appId = az ad app list `
+  --display-name $dbDeploySpnName `
+  --query [-1].appId `
+  --out tsv
+
+Graph-DeleteApplication --appId $appId
+
+Write-Host "  Now destroying SPN $mountSpnName !" -ForegroundColor Red
+$appId = az ad app list `
+  --display-name $mountSpnName `
+  --query [-1].appId `
+  --out tsv
+
+Graph-DeleteApplication --appId $appId
+
+###############################################################################################
+# Purge secrets
+###############################################################################################
+
+Write-Host "  Now purging secret for $dbDeploySpnName !" -ForegroundColor Red
+az keyvault secret purge --name $dbDeploySpnName --vault-name $keyVaultName
+
+Write-Host "  Now purging secret for $mountSpnName !" -ForegroundColor Red
+az keyvault secret purge --name $mountSpnName --vault-name $keyVaultName
+
+Write-Host "  SPNs Deleted" -ForegroundColor Green

--- a/.github/workflows/spn-cleanup.yml
+++ b/.github/workflows/spn-cleanup.yml
@@ -1,0 +1,28 @@
+
+# This pipeline can be runned if the SPNs needs to be destroyed
+# In this way, it is easier to clean up the SPNs, instead of manually removing them in the portal
+name: Spn-Cleanup
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: azure-integration
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Log in to azure
+        shell: pwsh
+        run: |
+          az login --service-principal `
+            -u ${{ secrets.SPN_CLIENT_ID }} `
+            -p ${{ secrets.SPN_CLIENT_SECRET }} `
+            --tenant ${{ secrets.SPN_TENANT_ID }}
+      - name: Delete Deployment
+        shell: pwsh
+        run: |
+          .github/deploy/destroy-spns.ps1


### PR DESCRIPTION
Sometimes there can be some conflict in the setup between the SPNs and the secret to apply them.

This workflow helps resetting (destroy) the spns and their respective secrets. The SPNs and secrets will be automatically created in the next PR.