### PR TITLE
fix: fix-delta-merge-when-running-in-stream

### DIFF
--- a/src/spetlr/delta/delta_handle.py
+++ b/src/spetlr/delta/delta_handle.py
@@ -209,7 +209,7 @@ class DeltaHandle(TableHandle):
             special_update_set="",
         )
 
-        Spark.get().sql(merge_sql_statement)
+        df._jdf.sparkSession().sql(merge_sql_statement)
 
         print("Incremental Base - incremental load with merge")
 


### PR DESCRIPTION
Fix issue in delta merge sql execution.

When doing delta merge within a streaming context, the temp view of the source dataframe can't be found.
Therefore the merge sql statement have to be run from a spark context on the dataframe.
This also works for normal batch merge.