### PR TITLE
SqlServer Driver versions are now configurable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
     - id: black
       language_version: python3.8

--- a/src/spetlr/sql/SqlServer.py
+++ b/src/spetlr/sql/SqlServer.py
@@ -13,7 +13,6 @@ from spetlr.configurator.configurator import Configurator
 from spetlr.spark import Spark
 from spetlr.sql.sql_handle import SqlHandle
 from spetlr.utils import GetMergeStatement
-
 from src.spetlr.sql.SqlServerBaseOptions import SqlServerBaseOptions
 
 

--- a/src/spetlr/sql/SqlServer.py
+++ b/src/spetlr/sql/SqlServer.py
@@ -14,6 +14,8 @@ from spetlr.spark import Spark
 from spetlr.sql.sql_handle import SqlHandle
 from spetlr.utils import GetMergeStatement
 
+from src.spetlr.sql.SqlServerBaseOptions import SqlServerBaseOptions
+
 
 class SqlServer:
     def __init__(
@@ -27,10 +29,13 @@ class SqlServer:
         *,
         spnid: str = None,
         spnpassword: str = None,
+        options: SqlServerBaseOptions = None,
     ):
         """Create object to interact with sql servers. Pass all but
         connection_string to connect via values or pass only the
         connection_string as a keyword param to connect via connection string"""
+        self.options = options or SqlServerBaseOptions()
+
         if connection_string is not None:
             hostname, port, username, password, database = self.from_connection_string(
                 connection_string
@@ -41,13 +46,12 @@ class SqlServer:
         self.timeout = 180  # 180 sec due to serverless
         self.sleep_time = 5  # Every 5 seconds the connection tries to be established
 
-        jdbc_driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
         self.url = (
             f"jdbc:sqlserver://{hostname}:{port};"
             f"database={database};"
             f"queryTimeout=0;"
             f"loginTimeout={self.timeout};"
-            f"driver={jdbc_driver};"
+            f"driver={self.options.jdbc_driver};"
         )
 
         if spnpassword and spnid and not password and not username:
@@ -68,7 +72,7 @@ class SqlServer:
             raise ValueError("Use either SPN or SQL user - never both")
 
         self.odbc = (
-            "DRIVER={ODBC Driver 17 for SQL Server};"
+            f"DRIVER={{{self.options.pyodbc_driver}}};"
             f"SERVER={hostname};"
             f"DATABASE={database};"
             f"PORT={port};"

--- a/src/spetlr/sql/SqlServer.py
+++ b/src/spetlr/sql/SqlServer.py
@@ -12,8 +12,8 @@ from pyspark.sql import DataFrame
 from spetlr.configurator.configurator import Configurator
 from spetlr.spark import Spark
 from spetlr.sql.sql_handle import SqlHandle
+from spetlr.sql.SqlServerBaseOptions import SqlServerBaseOptions
 from spetlr.utils import GetMergeStatement
-from src.spetlr.sql.SqlServerBaseOptions import SqlServerBaseOptions
 
 
 class SqlServer:

--- a/src/spetlr/sql/SqlServerBaseOptions.py
+++ b/src/spetlr/sql/SqlServerBaseOptions.py
@@ -1,0 +1,7 @@
+import dataclasses
+
+
+@dataclasses.dataclass
+class SqlServerBaseOptions:
+    jdbc_driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+    pyodbc_driver = "ODBC Driver 17 for SQL Server"


### PR DESCRIPTION
The default options for SQL Server hardcode the driver versions. When updating the drivers, this needs to be configurable.
This PR makes it configurable.