### PR TITLE
generalized entry points

### DIFF
--- a/docs/entry_points/README.md
+++ b/docs/entry_points/README.md
@@ -1,8 +1,13 @@
 # Entry points
 
-The `TaskEntryPoint` is an abstract base class that acts as an entry point for tasks. This class is meant to be subclassed and extended with specific implementation details. The subclass must implement a method `task()` which serves as the entry point for the task logic.
+## Entry Point Discovery
 
-## Usage
+The `TaskEntryPoint` is an abstract base class that acts as an entry point for tasks.
+This class is meant to be subclassed and extended with specific implementation 
+details.  The subclass must implement a method `task()` which serves as the entry 
+point for the task logic.
+
+### Usage
 
 To use `TaskEntryPoint`, create a subclass that implements the `task()` method:
 ```python
@@ -12,4 +17,41 @@ class MyTask(TaskEntryPoint):
                 # implement the task logic here
 ```
 
-It is now ensured that there is a `task()` method of the subclass `MyTask`, and we therefore have an entry point at `MyTask.task()`. This entry point can be added to the python wheel either manually or via automatic discovery.
+It is now ensured that there is a `task()` method of the subclass `MyTask`, and we
+therefore have an entry point at `MyTask.task()`. This entry point can be added to
+the python wheel either manually or via automatic discovery.
+
+## Light Entry Point
+
+Normally, to call code within a python wheel, an entry point must be specified in 
+the `setup.cfg` file. To skip this part, spetlr provides a standard entry point, 
+`spetlr_task`. Using this entry point, any other library code can be called.
+
+### Usage
+If you want to call this function:
+
+```python
+    def myfunction(myarg='default'): 
+        pass
+```
+
+that is residing in the file `mylib.myfolder.myfile`,
+then specify your task as follows:
+
+```json
+{
+  "python_wheel_task": {
+    "package_name": "spetlr",
+    "entry_point": "spetlr_task",
+    "named_parameters": {
+      "entry_point": "mylib.myfolder.myfile:myfunction",
+      "myarg": "myval"
+    }
+  }
+}
+```
+
+The `"package_name": "spetlr"` and  `"entry_point": "spetlr_task"` should always be 
+kept. The mandatory parameter 'entry_point' then points to the code to be called. 
+All further arguments, all of type `string`, will be passed to the called function as 
+named parameters.

--- a/docs/entry_points/README.md
+++ b/docs/entry_points/README.md
@@ -31,8 +31,8 @@ the `setup.cfg` file. To skip this part, spetlr provides a standard entry point,
 If you want to call this function:
 
 ```python
-    def myfunction(myarg='default'): 
-        pass
+def myfunction(myarg='default'): 
+    pass
 ```
 
 that is residing in the file `mylib.myfolder.myfile`,
@@ -52,6 +52,7 @@ then specify your task as follows:
 ```
 
 The `"package_name": "spetlr"` and  `"entry_point": "spetlr_task"` should always be 
-kept. The mandatory parameter 'entry_point' then points to the code to be called. 
+kept. The mandatory parameter 'entry_point' then points to the code to be called 
+[using standard format](https://packaging.python.org/en/latest/specifications/entry-points/). 
 All further arguments, all of type `string`, will be passed to the called function as 
 named parameters.

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ where = src
 [options.entry_points]
 console_scripts =
 	python3 = spetlr.alias:python3
+  spetlr_task = spetlr.entry_points.generalized_task_entry_point:main
 
 [flake8]
 exclude = .git,__pycache__,docs,build,dist,venv

--- a/src/spetlr/entry_points/generalized_task_entry_point.py
+++ b/src/spetlr/entry_points/generalized_task_entry_point.py
@@ -50,15 +50,12 @@ def main():
         raise Exception("No entry_point specified.")
 
     # entry_point looks like "my.module:main"
-    mod_name, func_name = entry_point.split(":", 1)
+    modname, qualname_separator, qualname = entry_point.partition(":")
 
-    mod = importlib.import_module(mod_name)
-
-    # we actually allow other forms of main, such as "MyClass.staticmethod"
-    # extract the callable
-    func = mod
-    for part in func_name.split("."):
-        func = getattr(func, part)
+    obj = importlib.import_module(modname)
+    if qualname_separator:
+        for attr in qualname.split("."):
+            obj = getattr(obj, attr)
 
     # call the callable with custom parameters
-    return func(**kwargs)
+    return obj(**kwargs)

--- a/src/spetlr/entry_points/generalized_task_entry_point.py
+++ b/src/spetlr/entry_points/generalized_task_entry_point.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+
+ENTRY_POINT = "entry_point"
+
+
+def main():
+    """This function is entry point from which another entry point can be called.
+    If you want to call this function:
+    ```python
+        def myfunction(myarg='default'): pass
+    ```
+    that is residing in the folder `mylib.myfolder.myfile`,
+    then specify your task as follows:
+    ```json
+        "python_wheel_task": {
+            "package_name": "spetlr",
+            "entry_point": "spetlr_task",
+            "named_parameters": {
+                "entry_point": "mylib.myfolder.myfile:myfunction",
+                "myarg": "myval"
+            }
+        }
+    ```
+    The named parameter 'entry_point' is mandatory.
+    All arguments must be of type string.
+    """
+
+    kwargs = {}
+    entry_point = None
+    for arg in sys.argv:
+        if not arg.startswith("--"):
+            continue
+        k, v = arg[2:].split("=")
+        if k == ENTRY_POINT:
+            entry_point = v
+        else:
+            kwargs[k] = v
+    if entry_point is None:
+        raise Exception("No entry_point specified.")
+
+    mod_name, func_name = entry_point.split(":")
+    mod = importlib.import_module(mod_name)
+    func = getattr(mod, func_name)
+
+    return func(**kwargs)


### PR DESCRIPTION
## Light Entry Point

Normally, to call code within a python wheel, an entry point must be specified in 
the `setup.cfg` file. To skip this part, spetlr provides a standard entry point, 
`spetlr_task`. Using this entry point, any other library code can be called.

### Usage
If you want to call this function:

```python
def myfunction(myarg='default'): 
    pass
```

that is residing in the file `mylib.myfolder.myfile`,
then specify your task as follows:

```json
{
  "python_wheel_task": {
    "package_name": "spetlr",
    "entry_point": "spetlr_task",
    "named_parameters": {
      "entry_point": "mylib.myfolder.myfile:myfunction",
      "myarg": "myval"
    }
  }
}
```

The `"package_name": "spetlr"` and  `"entry_point": "spetlr_task"` should always be 
kept. The mandatory parameter 'entry_point' then points to the code to be called 
[using standard format](https://packaging.python.org/en/latest/specifications/entry-points/). 
All further arguments, all of type `string`, will be passed to the called function as 
named parameters.

---

This addition completely eliminates the need to create entry points in the project `setup.cfg` which I find much cleaner.

---

There are no test here since I don't know how to test this in the pipeline. I have however tested this code by using is in a project ant it works as expected.