### PR TITLE
feat: clean spark test databases

### DIFF
--- a/docs/utilities/README.md
+++ b/docs/utilities/README.md
@@ -5,6 +5,7 @@ Utilities in spetlr:
 * [Api Auto Config](#api-auto-config)
 * [Test Utilities](#test-utilities)
 * [Git Hooks](#git-hooks)
+* [Cleanup Test Tables](#cleanup-test-tables)
 
 ## Api Auto Config
 
@@ -85,3 +86,22 @@ To uninstall the hooks, simply run this command
 
     spetlr-git-hooks uninstall
 
+## Cleanup Test Tables
+When using the SPETLR Configurator to create abstraction of tables (test/debug tables),
+it becomes handy to have an easy way of removing the test tables.
+
+This can be achieved in the following ways:
+
+
+### Delta Databases (and their tables)
+
+```python
+from spetlrtools.testing import DataframeTestCase
+from spetlr.utils import CleanupTestDatabases
+
+class ExampleTests(DataframeTestCase):
+    
+    @classmethod
+    def tearDownClass(cls) -> None:
+        CleanupTestDatabases()
+```

--- a/src/spetlr/configurator/configurator.py
+++ b/src/spetlr/configurator/configurator.py
@@ -68,7 +68,6 @@ class Configurator(metaclass=ConfiguratorSingleton):
     def _set_extras(self):
         self.register("ID", {"release": "", "debug": f"__{self._unique_id}"})
         self.register("MNT", {"release": "mnt", "debug": "tmp"})
-        self.register("Config_UUID_SPETLR", f"__{self._unique_id}")
 
     @deprecated(
         reason="use .get('ENV') to get literal values.",

--- a/src/spetlr/exceptions/__init__.py
+++ b/src/spetlr/exceptions/__init__.py
@@ -55,3 +55,8 @@ class NoSuchValueException(SpetlrKeyError):
 class MissingUpsertJoinColumns(SpetlrKeyError):
     value = "You must specify upsert_join_cols"
     pass
+
+
+class OnlyUseInSpetlrDebugMode(SpetlrKeyError):
+    value = "Only call this if the configurator is in debug"
+    pass

--- a/src/spetlr/utils/CleanupTestDatabases.py
+++ b/src/spetlr/utils/CleanupTestDatabases.py
@@ -4,8 +4,6 @@ from spetlr.config_master import Configurator
 from spetlr.exceptions import OnlyUseInSpetlrDebugMode
 from spetlr.spark import Spark
 
-_time_spent = 0
-
 
 def CleanupTestDatabases():
     """
@@ -17,9 +15,7 @@ def CleanupTestDatabases():
     if not c.is_debug():
         raise OnlyUseInSpetlrDebugMode()
 
-    start = time.time()
-
-    id_extension = c.get_all_details()["ID"]
+    id_extension = c.get("ID")
 
     dbs = Spark.get().sql("SHOW DATABASES").collect()
     for (db,) in dbs:
@@ -27,8 +23,3 @@ def CleanupTestDatabases():
             print(f"Now deleting database {db}")
             Spark.get().sql(f"DROP DATABASE {db} CASCADE")
     print("Database cleanup done.")
-
-    end = time.time()
-    global _time_spent
-    _time_spent += end - start
-    print(f"CleanupTestDatabases total execution time so far: {_time_spent}")

--- a/src/spetlr/utils/CleanupTestDatabases.py
+++ b/src/spetlr/utils/CleanupTestDatabases.py
@@ -1,5 +1,3 @@
-import time
-
 from spetlr.config_master import Configurator
 from spetlr.exceptions import OnlyUseInSpetlrDebugMode
 from spetlr.spark import Spark

--- a/src/spetlr/utils/CleanupTestDatabases.py
+++ b/src/spetlr/utils/CleanupTestDatabases.py
@@ -1,0 +1,34 @@
+import time
+
+from spetlr.config_master import Configurator
+from spetlr.exceptions import OnlyUseInSpetlrDebugMode
+from spetlr.spark import Spark
+
+_time_spent = 0
+
+
+def CleanupTestDatabases():
+    """
+    This function can be applied for removing test databases
+    in the Databricks Environment.
+    """
+
+    c = Configurator()
+    if not c.is_debug():
+        raise OnlyUseInSpetlrDebugMode()
+
+    start = time.time()
+
+    id_extension = c.get_all_details()["ID"]
+
+    dbs = Spark.get().sql("SHOW DATABASES").collect()
+    for (db,) in dbs:
+        if db.endswith(id_extension):
+            print(f"Now deleting database {db}")
+            Spark.get().sql(f"DROP DATABASE {db} CASCADE")
+    print("Database cleanup done.")
+
+    end = time.time()
+    global _time_spent
+    _time_spent += end - start
+    print(f"CleanupTestDatabases total execution time so far: {_time_spent}")

--- a/src/spetlr/utils/__init__.py
+++ b/src/spetlr/utils/__init__.py
@@ -1,3 +1,4 @@
+from .CleanupTestDatabases import CleanupTestDatabases
 from .DataframeCreator import DataframeCreator
 from .DropOldestDuplicates import DropOldestDuplicates
 from .GetMergeStatement import GetMergeStatement
@@ -12,4 +13,5 @@ __all__ = [
     MockExtractor,
     DropOldestDuplicates,
     SelectAndCastColumns,
+    CleanupTestDatabases,
 ]

--- a/tests/cluster/delta/extras/tablenames.yml
+++ b/tests/cluster/delta/extras/tablenames.yml
@@ -1,6 +1,6 @@
 SparkTestDb:
   name: my_db1{ID}
-  path: /tmp/foo/bar/my_db1/
+  path: /tmp/foo/bar/my_db1{ID}/
 
 SparkTestTable1:
   name: "{SparkTestDb}.tbl1"
@@ -11,7 +11,7 @@ SparkTestTable11:
 
 SparkTestDb2:
   name: my_db2{ID}
-  path: /tmp/foo/bar/my_db2/
+  path: /tmp/foo/bar/my_db2{ID}/
 
 SparkTestTable2:
   name: "{SparkTestDb2}.tbl2"

--- a/tests/cluster/delta/test_cleanup_databases.py
+++ b/tests/cluster/delta/test_cleanup_databases.py
@@ -1,0 +1,117 @@
+import unittest
+
+from pyspark.sql.utils import AnalysisException
+
+from spetlr import Configurator
+from spetlr.delta import DbHandle, DeltaHandle
+from spetlr.spark import Spark
+from spetlr.utils.CleanupTestDatabases import CleanupTestDatabases
+from tests.cluster.delta import extras
+from tests.cluster.delta.SparkExecutor import SparkSqlExecutor
+
+
+class CleanTestTablesTests(unittest.TestCase):
+    """
+    This tests simulates the concurrent execution of two tests:
+
+    Test A:
+    Spark SQL databases is created with SPETLR Configurator debug IDs.
+
+    Test B:
+    Spark SQL databases is created with ANOTHER SPETLR Configurator debug ID.
+    The CleanTestDatabases is executed in the tearDownClass.
+
+    Goal:
+    Test A databases should not be affected.
+
+    NB: This test utilizes the Configurator in a non-trivial manner.
+        It is not recommended to replicate this test or Configurator setup.
+    """
+
+    dh = None
+    tc = None
+    dbh = None
+
+    @classmethod
+    def setUpClass(cls):
+        # Register the delivery table for the table configurator
+        cls.setup_conf()
+
+        cls.dbh = DbHandle
+        cls.dh = DeltaHandle
+
+        # Ensure no table is there
+        cls.dbh.from_tc("SparkTestDb").drop_cascade()
+        cls.dh.from_tc("SparkTestTable1").drop()
+        cls.dbh.from_tc("SparkTestDb2").drop_cascade()
+        cls.dh.from_tc("SparkTestTable2").drop()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbh.from_tc("SparkTestDb").drop_cascade()
+        cls.dh.from_tc("SparkTestTable1").drop()
+        cls.dbh.from_tc("SparkTestDb2").drop_cascade()
+        cls.dh.from_tc("SparkTestTable2").drop()
+
+    def test_01_remove_only_current_UUID_tables(self):
+        """
+        Test remove only the current UUID databases.
+
+        - Creates databases and saves table names.
+        - Verifies that tables are readable.
+        - Generates a new UUID and recreates the tables (and databases).
+        - Verifies that the new tables are readable.
+        - Cleans up the new databases.
+        - Verifies that the old tables still exist and the new tables are removed.
+        """
+        # Create tables and save table names
+        SparkSqlExecutor().execute_sql_file("test1")
+        SparkSqlExecutor().execute_sql_file("test2_debug")
+        old_table_name_1 = self.tc.table_name("SparkTestTable1")
+        old_table_name_2 = self.tc.table_name("SparkTestTable2")
+
+        # Should be able to read tables here
+        old_df_1 = Spark.get().table(old_table_name_1)
+        old_df_2 = Spark.get().table(old_table_name_2)
+
+        self.assertEqual(old_df_1.count(), 0)
+        self.assertEqual(old_df_2.count(), 0)
+
+        # Create a new UUID
+        self.tc.regenerate_unique_id_and_clear_conf()
+        self.setup_conf()
+
+        SparkSqlExecutor().execute_sql_file("test1")
+        SparkSqlExecutor().execute_sql_file("test2_debug")
+        new_table_name_1 = self.tc.table_name("SparkTestTable1")
+        new_table_name_2 = self.tc.table_name("SparkTestTable2")
+
+        # Should be able to read tables here
+        new_df_1 = Spark.get().table(new_table_name_1)
+        new_df_2 = Spark.get().table(new_table_name_2)
+
+        self.assertEqual(new_df_1.count(), 0)
+        self.assertEqual(new_df_2.count(), 0)
+
+        # Cleanup new tables
+        CleanupTestDatabases()
+
+        # The old tables should still exist
+        old_df_1 = Spark.get().table(old_table_name_1)
+        old_df_2 = Spark.get().table(old_table_name_2)
+
+        self.assertEqual(old_df_1.count(), 0)
+        self.assertEqual(old_df_2.count(), 0)
+
+        # The new tables should be removed
+        with self.assertRaises(AnalysisException):
+            Spark.get().table(new_table_name_1)
+
+        with self.assertRaises(AnalysisException):
+            Spark.get().table(new_table_name_2)
+
+    @classmethod
+    def setup_conf(cls):
+        cls.tc = Configurator()
+        cls.tc.add_resource_path(extras)
+        cls.tc.set_debug()

--- a/tests/local/configurator/test_configurator.py
+++ b/tests/local/configurator/test_configurator.py
@@ -204,35 +204,3 @@ class TestConfigurator(unittest.TestCase):
 
         self.assertEqual(first_extension, "")
         self.assertEqual(second_extension, "")
-
-    def test_12_get_config_uuid_spetlr_debug(self):
-        """
-        The UUID can also be reached as a
-        fictive table name 'Config_UUID_SPETLR'.
-
-        In debug, ID and Config_UUID_SPETLR is equal.
-        """
-        c = Configurator()
-        c.clear_all_configurations()
-        c.set_debug()
-
-        id_extension = c.get_all_details()["ID"]
-        config_uuid_spetlr = c.get_all_details()["Config_UUID_SPETLR"]
-
-        self.assertEqual(id_extension, config_uuid_spetlr)
-
-    def test_13_get_config_uuid_spetlr_prod(self):
-        """
-        The UUID can also be reached as a
-        fictive table name 'Config_UUID_SPETLR'.
-
-        In production, ID and Config_UUID_SPETLR is different.
-        """
-        c = Configurator()
-        c.clear_all_configurations()
-        c.set_prod()
-
-        id_extension = c.get_all_details()["ID"]
-        config_uuid_spetlr = c.get_all_details()["Config_UUID_SPETLR"]
-
-        self.assertNotEqual(id_extension, config_uuid_spetlr)

--- a/tests/local/configurator/test_configurator_cli.py
+++ b/tests/local/configurator/test_configurator_cli.py
@@ -39,7 +39,6 @@ class TestConfiguratorCli(unittest.TestCase):
                 # AUTO GENERATED FILE
                 # contains all spetlr.Configurator keys
 
-                Config_UUID_SPETLR = "Config_UUID_SPETLR"
                 ID = "ID"
                 MNT = "MNT"
                 MyAlias = "MyAlias"

--- a/tests/local/utils/test_cleandatabases.py
+++ b/tests/local/utils/test_cleandatabases.py
@@ -1,0 +1,10 @@
+import unittest
+
+from spetlr.exceptions import OnlyUseInSpetlrDebugMode
+from spetlr.utils import CleanupTestDatabases
+
+
+class CleanUpDatabasesAndTablesUnitTest(unittest.TestCase):
+    def test_01_debug_databases(self):
+        with self.assertRaises(OnlyUseInSpetlrDebugMode):
+            CleanupTestDatabases()


### PR DESCRIPTION
This PR introduces methods for easily remove test tables from Databricks:

* CleanupTestDatabases
  * Removes spark test databases