### PR TITLE
docs: renaming spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # spetlr
-A python SPark ETL libRary (SPETLR) for Databricks. 
+A python ETL libRary (SPETLR) for Databricks powered by Apache SPark. 
 
 Visit SPETLR official webpage: [https://spetlr.com/](https://spetlr.com/)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,11 +2,11 @@
 name = spetlr
 author = Spetlr.Org
 version = file: src/VERSION.txt
-description = A python SPark ETL libRary (SPETLR) for Databricks.
+description = A python ETL libRary (SPETLR) for Databricks powered by Apache SPark.
 long_description = file: README.md
 long_description_content_type = text/markdown
 author_email = spetlr.org@gmail.com
-url = https://github.com/atc-net/atc-dataplatform
+url = https://github.com/spetlr-org/spetlr
 keywords = databricks, pyspark
 license_files = LICENSE
 project_urls =


### PR DESCRIPTION
We should follow the trademark guidelines: https://spark.apache.org/trademarks.html