### PR TITLE
Create transformer for generating md5 encoded column

### DIFF
--- a/docs/transformations/README.md
+++ b/docs/transformations/README.md
@@ -13,8 +13,9 @@ Transformations in spetlr:
   - [TimeZoneTransformer](#timezonetransformer)
   - [SelectAndCastColumnsTransformer](#selectandcastcolumnstransformer)
   - [ValidFromToTransformer](#validfromtotransformer)
-  - [DataFrameFilterTransformer](#DataFrameFilterTransformer)
-
+  - [DataFrameFilterTransformer](#dataframefiltertransformer)
+  - [CountryToAlphaCodeTransformerNC](#countrytoalphacodetransformernc)
+  - [GenerateMd5ColumnTransformer](#generatemd5columntransformer)
 ## Concatenate data frames
 
 *UPDATE: Pyspark has an equivalent implementation  `.unionByName(df, allowMissingColumns=False)`, see the [documentation](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.unionByName.html) for more information.*
@@ -470,4 +471,45 @@ transformed_df.display()
 |   Germany|          DE|
 +----------+------------+
 
+```
+
+## GenerateMd5ColumnTransformer
+
+This transformer generates a unique column with md5 encoding based on other columns. The transformer also handles if a value is NULL, by replacing it with empty string.
+
+Usage example
+
+```python
+from spetlr.transformers import GenerateMd5ColumnTransformerNC
+import pyspark.sql.types as T
+
+from spetlr.spark import Spark
+input_schema = T.StructType(
+    [
+        T.StructField("id", T.IntegerType(), True),
+        T.StructField("text", T.StringType(), True),
+    ]
+)
+
+input_data = [
+    (1, "text1"),
+    (2, None),
+]
+
+input_df = Spark.get().createDataFrame(data=input_data, schema=input_schema)
+
+transformed_df = GenerateMd5ColumnTransformerNC(
+    col_name="md5_col",
+    col_list=["id", "text"],
+).process(input_df)
+
+
+transformed_df.display()
+
++-----+-------+----------------------------------+
+|   id|   text|                           md5_col|
++-----+-------+----------------------------------+
+|    1|  text1|  e86667d75db79395e172c5c343ec2df1|
+|    2|   Null|  c81e728d9d4c2f636f067f89cc14862c|
++-----+-------+-----------------------------------+
 ```

--- a/src/spetlr/transformers/__init__.py
+++ b/src/spetlr/transformers/__init__.py
@@ -5,6 +5,9 @@ from .drop_oldest_duplicate_transformer import (  # noqa: F401
     DropOldestDuplicatesTransformer,
 )
 from .dropColumnsTransformer_nc import DropColumnsTransformerNC  # noqa: F401
+from .generate_md5_column_transformer_nc import (  # noqa: F401
+    GenerateMd5ColumnTransformerNC,
+)
 from .join_dataframes_transformer import JoinDataframesTransformerNC  # noqa: F401
 from .select_and_cast_columns_transformer_nc import (  # noqa: F401
     SelectAndCastColumnsTransformerNC,

--- a/src/spetlr/transformers/generate_md5_column_transformer_nc.py
+++ b/src/spetlr/transformers/generate_md5_column_transformer_nc.py
@@ -1,0 +1,60 @@
+import uuid
+from typing import List, Union
+
+import pyspark.sql.functions as F
+import pyspark.sql.types as T
+from pyspark.sql import DataFrame
+
+from spetlr.etl import TransformerNC
+
+
+class GenerateMd5ColumnTransformerNC(TransformerNC):
+    """
+    This transformer generates a unique column with md5 encoding based on other columns.
+    The transformer also handles if a value is NULL, by replacing it with empty string.
+
+    Attributes:
+    ----------
+        col_name : String
+            name of the column to put the md5 encoding
+        col_list : List[str]
+            list of columns to use for the md5 encoding
+        dataset_input_keys : Union[str, List[str]]
+            list of input dataset keys
+        dataset_output_key : str
+            output dataset key
+    """
+
+    def __init__(
+        self,
+        *,
+        col_name: str,
+        col_list: List[str],
+        dataset_input_keys: Union[str, List[str]] = None,
+        dataset_output_key: str = None,
+    ):
+        super().__init__(
+            dataset_input_keys=dataset_input_keys,
+            dataset_output_key=dataset_output_key,
+        )
+        self.col_name = col_name
+        self.col_list = col_list
+
+    def process(self, df: DataFrame) -> DataFrame:
+        temp_col_list = []
+        for col in self.col_list:
+            # Place null safe value in temp column
+            temp_col_name = str(uuid.uuid4())
+            temp_col_list.append(temp_col_name)
+
+            # Cast column to string
+            # Coalesce with empty string in order to ensure md5 enablement
+            _query = F.coalesce(F.col(col).cast(T.StringType()), F.lit(""))
+
+            df = df.withColumn(temp_col_name, _query)
+
+        df = df.withColumn(self.col_name, F.md5(F.concat(*temp_col_list)))
+
+        df = df.drop(*temp_col_list)
+
+        return df

--- a/tests/local/transformers/test_generate_md5_column_transformer_nc.py
+++ b/tests/local/transformers/test_generate_md5_column_transformer_nc.py
@@ -1,0 +1,69 @@
+import hashlib
+
+import pyspark.sql.types as T
+from spetlrtools.testing import DataframeTestCase
+
+from spetlr.spark import Spark
+from spetlr.transformers import GenerateMd5ColumnTransformerNC
+
+
+class TestGenerateMd5ColumnTransformerNC(DataframeTestCase):
+    def test_generate_md5_column(self):
+        input_schema = T.StructType(
+            [
+                T.StructField("id", T.IntegerType(), True),
+                T.StructField("text", T.StringType(), True),
+            ]
+        )
+
+        input_data = [
+            (1, "text1"),
+            (2, "text2"),
+        ]
+
+        df_input = Spark.get().createDataFrame(data=input_data, schema=input_schema)
+
+        df_transformed = GenerateMd5ColumnTransformerNC(
+            col_name="md5_col",
+            col_list=["id", "text"],
+        ).process(df_input)
+
+        expected_data = [
+            (1, "text1", hashlib.md5("1text1".encode()).hexdigest()),
+            (2, "text2", hashlib.md5("2text2".encode()).hexdigest()),
+        ]
+
+        self.assertDataframeMatches(
+            df=df_transformed,
+            expected_data=expected_data,
+        )
+
+    def test_generate_md5_column_with_nulls(self):
+        input_schema = T.StructType(
+            [
+                T.StructField("id", T.IntegerType(), True),
+                T.StructField("text", T.StringType(), True),
+            ]
+        )
+
+        input_data = [
+            (1, "text1"),
+            (2, None),
+        ]
+
+        df_input = Spark.get().createDataFrame(data=input_data, schema=input_schema)
+
+        df_transformed = GenerateMd5ColumnTransformerNC(
+            col_name="md5_col",
+            col_list=["id", "text"],
+        ).process(df_input)
+
+        expected_data = [
+            (1, "text1", hashlib.md5("1text1".encode()).hexdigest()),
+            (2, None, hashlib.md5(("2" + "").encode()).hexdigest()),
+        ]
+
+        self.assertDataframeMatches(
+            df=df_transformed,
+            expected_data=expected_data,
+        )


### PR DESCRIPTION
Create transformer for generating md5 encoded column based on other columns.
The transformer also handles if a value is NULL, by replacing it with empty string.