### PR TITLE
fix: fix inputtype to transformerNC

### DIFF
--- a/src/spetlr/etl/transformer_nc.py
+++ b/src/spetlr/etl/transformer_nc.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import List, Union
+from typing import List
 
 from deprecated import deprecated
 from pyspark.sql import DataFrame
@@ -23,14 +23,9 @@ class TransformerNC(Transformer):
     def __init__(
         self,
         *,
-        dataset_input_keys: Union[str, List[str]] = None,
+        dataset_input_keys: List[str] = None,
         dataset_output_key: str = None,
     ):
-        if isinstance(dataset_input_keys, str):
-            dataset_input_keys = [dataset_input_keys]
-        else:
-            dataset_input_keys = dataset_input_keys
-
         super().__init__(
             dataset_input_keys=dataset_input_keys,
             dataset_output_key=dataset_output_key,

--- a/src/spetlr/transformers/country_to_alphacode_transformer_nc.py
+++ b/src/spetlr/transformers/country_to_alphacode_transformer_nc.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List
 
 import pycountry
 import pyspark.sql.functions as F
@@ -31,7 +31,7 @@ class CountryToAlphaCodeTransformerNC(TransformerNC):
         self,
         col_name: str,
         output_col_name: str = None,
-        dataset_input_keys: Union[str, List[str]] = None,
+        dataset_input_keys: List[str] = None,
         dataset_output_key: str = None,
     ) -> None:
         """

--- a/src/spetlr/transformers/dropColumnsTransformer_nc.py
+++ b/src/spetlr/transformers/dropColumnsTransformer_nc.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List
 
 from pyspark.sql import DataFrame
 
@@ -10,7 +10,7 @@ class DropColumnsTransformerNC(TransformerNC):
         self,
         *,
         columnList: List[str],
-        dataset_input_keys: Union[str, List[str]] = None,
+        dataset_input_keys: List[str] = None,
         dataset_output_key: str = None,
     ):
         super().__init__(

--- a/src/spetlr/transformers/generate_md5_column_transformer_nc.py
+++ b/src/spetlr/transformers/generate_md5_column_transformer_nc.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List, Union
+from typing import List
 
 import pyspark.sql.functions as F
 import pyspark.sql.types as T
@@ -30,7 +30,7 @@ class GenerateMd5ColumnTransformerNC(TransformerNC):
         *,
         col_name: str,
         col_list: List[str],
-        dataset_input_keys: Union[str, List[str]] = None,
+        dataset_input_keys: List[str] = None,
         dataset_output_key: str = None,
     ):
         super().__init__(

--- a/src/spetlr/transformers/selectColumnsTransformer_nc.py
+++ b/src/spetlr/transformers/selectColumnsTransformer_nc.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List
 
 from pyspark.sql import DataFrame
 
@@ -10,7 +10,7 @@ class SelectColumnsTransformerNC(TransformerNC):
         self,
         *,
         columnList: List[str],
-        dataset_input_keys: Union[str, List[str]] = None,
+        dataset_input_keys: List[str] = None,
         dataset_output_key: str = None,
     ):
         super().__init__(

--- a/src/spetlr/transformers/select_and_cast_columns_transformer_nc.py
+++ b/src/spetlr/transformers/select_and_cast_columns_transformer_nc.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List
 
 import pyspark.sql.types as T
 from pyspark.sql import DataFrame
@@ -28,7 +28,7 @@ class SelectAndCastColumnsTransformerNC(TransformerNC):
         *,
         schema: T.StructType,
         caseInsensitiveMatching: bool = False,
-        dataset_input_keys: Union[str, List[str]] = None,
+        dataset_input_keys: List[str] = None,
         dataset_output_key: str = None,
     ):
         super().__init__(

--- a/src/spetlr/transformers/simple_dataframe_filter_transformer_nc.py
+++ b/src/spetlr/transformers/simple_dataframe_filter_transformer_nc.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List
 
 import pyspark.sql.functions as F
 from pyspark.sql import DataFrame
@@ -11,7 +11,7 @@ class DataFrameFilterTransformerNC(TransformerNC):
         self,
         col_name: str,
         col_value: str,
-        dataset_input_keys: Union[str, List[str]] = None,
+        dataset_input_keys: List[str] = None,
         dataset_output_key: str = None,
     ) -> None:
         """

--- a/src/spetlr/transformers/timezone_transformer_nc.py
+++ b/src/spetlr/transformers/timezone_transformer_nc.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List
 
 import pyspark.sql.functions as F
 from pyspark.sql import DataFrame
@@ -38,7 +38,7 @@ class TimeZoneTransformerNC(TransformerNC):
         latitude_col: str,
         longitude_col: str,
         column_output_name: str = "TimeZone",
-        dataset_input_keys: Union[str, List[str]] = None,
+        dataset_input_keys: List[str] = None,
         dataset_output_key: str = None,
     ):
         super().__init__(

--- a/src/spetlr/transformers/union_transformer_nc.py
+++ b/src/spetlr/transformers/union_transformer_nc.py
@@ -1,5 +1,5 @@
 from functools import reduce
-from typing import List, Union
+from typing import List
 
 from pyspark.sql import DataFrame
 
@@ -31,7 +31,7 @@ class UnionTransformerNC(TransformerNC):
         self,
         *,
         allowMissingColumns: bool = False,
-        dataset_input_keys: Union[str, List[str]] = None,
+        dataset_input_keys: List[str] = None,
         dataset_output_key: str = None,
     ):
         super().__init__(

--- a/tests/local/etl/test_transformer_nc.py
+++ b/tests/local/etl/test_transformer_nc.py
@@ -15,7 +15,7 @@ class TransformerNCTests(unittest.TestCase):
         cls.df = create_dataframe()
 
         cls.transformer_output_key = TestTransformer(dataset_output_key="my_output_key")
-        cls.transformer_input_key = TestTransformer(dataset_input_keys="my_input_key")
+        cls.transformer_input_key = TestTransformer(dataset_input_keys=["my_input_key"])
         cls.transformer_input_key_list = TestTransformer(
             dataset_input_keys=["my_input_key_1", "my_input_key_2"]
         )


### PR DESCRIPTION
**UPDATE: I would rather merge #82. And then close this PR.**

When inherit from TransformerNC, there can occur some issues regarding the dataset_input_keys. When adding super().__init__ to a transformer that inherits from TransformerNC, the inputs will be a string-type. Therefore, there ETL thinks it should call process_many.


```python
class TestInheritTransformerNC(TransformerNC):
   

    def __init__(
        self,
        *,
        dataset_input_keys: Union[str, List[str]] = None,
        dataset_output_key: str = None,
    ):
        super().__init__(
            dataset_input_keys=dataset_input_keys,
            dataset_output_key=dataset_output_key,
        )
```

If the dataset_input_key here is a `str`, the transformerNC does not properly convert the the input as a list.

I think it is much more robust to control the input datatype instead. 


see this bug: #76 