### PR TITLE
feat: remove tasks from template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,7 +1,7 @@
 ## This issue is a ...
 
-- [ ] bug report
-- [ ] feature request
+- Bug report
+- Feature request
 
 ## Initial description
 *Please provide a description of the issue.*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,11 @@
 ## What type of PR is this? (check all applicable)
 
-- [ ] Refactor
-- [ ] Feature
-- [ ] Bug Fix
-- [ ] Optimization
-- [ ] Deployment (Azure, CI/CD, PowerShell, ...)
-- [ ] Documentation Update
+- Refactor
+- Feature
+- Bug Fix
+- Optimization
+- Deployment (Azure, CI/CD, PowerShell, ...)
+- Documentation Update
 
 ## Description
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Documentation Update

## Description

### Overview
The templates have tasks that can be marked with crosses. "[ ]". These are removed now.

### What is the current behavior?
Crosses are marked in the templates, but this introduces a visual in the PR and issue overview.
These tasks are more confusing than beneficial. 

### What is the new behavior?
The marks are simply removed. 

