### PR TITLE
feat: add upsert to simpleloader

### DIFF
--- a/src/spetlr/etl/loaders/UpsertLoader.py
+++ b/src/spetlr/etl/loaders/UpsertLoader.py
@@ -1,11 +1,15 @@
 from typing import List, Union
 
+from deprecated import deprecated
 from pyspark.sql import DataFrame
 
 from spetlr.etl import Loader, dataset_group
 from spetlr.tables import TableHandle
 
 
+@deprecated(
+    reason="use SimpleLoader(mode=upsert) instead",
+)
 class UpsertLoader(Loader):
     def __init__(
         self,

--- a/src/spetlr/etl/loaders/__init__.py
+++ b/src/spetlr/etl/loaders/__init__.py
@@ -1,3 +1,4 @@
+from .load_modes import Appendable, Overwritable, Upsertable  # noqa: F401
 from .simple_loader import SimpleLoader  # noqa: F401
 from .simple_sql_loader import SimpleSqlServerLoader  # noqa: F401
 from .upsert_loader_streaming import UpsertLoaderStreaming  # noqa: F401

--- a/src/spetlr/etl/loaders/load_modes.py
+++ b/src/spetlr/etl/loaders/load_modes.py
@@ -1,0 +1,18 @@
+from typing import List, Protocol, Union
+
+from pyspark.sql import DataFrame
+
+
+class Upsertable(Protocol):
+    def upsert(self, df: DataFrame, join_cols: List[str]) -> Union[DataFrame, None]:
+        pass
+
+
+class Overwritable(Protocol):
+    def overwrite(self, df: DataFrame) -> None:
+        pass
+
+
+class Appendable(Protocol):
+    def append(self, df: DataFrame) -> None:
+        pass

--- a/src/spetlr/etl/loaders/simple_loader.py
+++ b/src/spetlr/etl/loaders/simple_loader.py
@@ -1,23 +1,9 @@
-from typing import List, Protocol, Union
+from typing import List, Union
 
 from pyspark.sql import DataFrame
 
 from spetlr.etl import Loader
-
-
-class Overwritable(Protocol):
-    def overwrite(self, df: DataFrame) -> None:
-        pass
-
-
-class Appendable(Protocol):
-    def append(self, df: DataFrame) -> None:
-        pass
-
-
-class Upsertable(Protocol):
-    def upsert(self, df: DataFrame, join_cols: List[str]) -> Union[DataFrame, None]:
-        pass
+from spetlr.etl.loaders import Appendable, Overwritable, Upsertable
 
 
 class SimpleLoader(Loader):
@@ -27,10 +13,10 @@ class SimpleLoader(Loader):
         *,
         mode: str = "overwrite",
         join_cols: List[str] = None,
-        dataset_input_keys: Union[str, List[str]] = None,
+        dataset_input_keys: List[str] = None,
     ):
         super().__init__(dataset_input_keys=dataset_input_keys)
-        self.mode = mode
+        self.mode = mode.lower()
         self.handle = handle
         self.join_cols = join_cols
 

--- a/src/spetlr/etl/loaders/simple_loader.py
+++ b/src/spetlr/etl/loaders/simple_loader.py
@@ -15,20 +15,29 @@ class Appendable(Protocol):
         pass
 
 
+class Upsertable(Protocol):
+    def upsert(self, df: DataFrame, join_cols: List[str]) -> Union[DataFrame, None]:
+        pass
+
+
 class SimpleLoader(Loader):
     def __init__(
         self,
-        handle: Union[Overwritable, Appendable],
+        handle: Union[Overwritable, Appendable, Upsertable],
         *,
         mode: str = "overwrite",
+        join_cols: List[str] = None,
         dataset_input_keys: Union[str, List[str]] = None,
     ):
         super().__init__(dataset_input_keys=dataset_input_keys)
         self.mode = mode
         self.handle = handle
+        self.join_cols = join_cols
 
     def save(self, df: DataFrame) -> None:
         if self.mode == "overwrite":
             self.handle.overwrite(df)
+        elif self.mode == "upsert":
+            self.handle.upsert(df, self.join_cols)
         else:
             self.handle.append(df)

--- a/src/spetlr/etl/loaders/upsert_loader_streaming.py
+++ b/src/spetlr/etl/loaders/upsert_loader_streaming.py
@@ -3,8 +3,8 @@ from typing import List
 from pyspark.sql import DataFrame
 
 from spetlr.etl import Loader, dataset_group
+from spetlr.etl.loaders import SimpleLoader
 from spetlr.etl.loaders.stream_loader import StreamLoader
-from spetlr.etl.loaders.UpsertLoader import UpsertLoader
 from spetlr.tables import TableHandle
 
 
@@ -23,7 +23,9 @@ class UpsertLoaderStreaming(Loader):
         super().__init__()
 
         self._loader = StreamLoader(
-            loader=UpsertLoader(handle=handle, join_cols=upsert_join_cols),
+            loader=SimpleLoader(
+                handle=handle, join_cols=upsert_join_cols, mode="upsert"
+            ),
             options_dict=options_dict,
             trigger_type=trigger_type,
             trigger_time_seconds=trigger_time_seconds,

--- a/src/spetlr/orchestrators/eh2silver/EhToDeltaSilverOrchestrator.py
+++ b/src/spetlr/orchestrators/eh2silver/EhToDeltaSilverOrchestrator.py
@@ -4,7 +4,6 @@ from spetlr.delta import DeltaHandle
 from spetlr.etl import EtlBase, Orchestrator
 from spetlr.etl.extractors import IncrementalExtractor, SimpleExtractor
 from spetlr.etl.loaders import SimpleLoader
-from spetlr.etl.loaders.UpsertLoader import UpsertLoader
 from spetlr.exceptions import MissingUpsertJoinColumns
 from spetlr.orchestrators.ehjson2delta.EhJsonToDeltaTransformer import (
     EhJsonToDeltaTransformer,
@@ -65,12 +64,9 @@ class EhToDeltaSilverOrchestrator(Orchestrator):
 
         # the method filter_with can be used to insert any number of transformers here
 
-        # final step,
-        # by default upsert the rows to the silver delta table.
-        if mode == "upsert":
-            self._loader = UpsertLoader(dh_target, self.upsert_join_cols)
-        else:
-            self._loader = SimpleLoader(dh_target, mode=self.mode)
+        self._loader = SimpleLoader(
+            dh_target, join_cols=self.upsert_join_cols, mode=self.mode
+        )
 
         self.load_into(self._loader)
 

--- a/tests/cluster/etl/test_simpleloader_upsert.py
+++ b/tests/cluster/etl/test_simpleloader_upsert.py
@@ -10,7 +10,7 @@ from tests.cluster.delta import extras
 from tests.cluster.delta.SparkExecutor import SparkSqlExecutor
 
 
-class UpsertLoaderTests(DataframeTestCase):
+class SimpleLoaderUpsertTests(DataframeTestCase):
     target_id = "UpsertLoaderDummy"
 
     join_cols = ["col1", "col2"]

--- a/tests/cluster/etl/test_simpleloader_upsert.py
+++ b/tests/cluster/etl/test_simpleloader_upsert.py
@@ -1,0 +1,99 @@
+from typing import List
+
+from spetlrtools.testing import DataframeTestCase
+
+from spetlr import Configurator
+from spetlr.delta import DbHandle, DeltaHandle
+from spetlr.etl.loaders import SimpleLoader
+from spetlr.utils import DataframeCreator
+from tests.cluster.delta import extras
+from tests.cluster.delta.SparkExecutor import SparkSqlExecutor
+
+
+class UpsertLoaderTests(DataframeTestCase):
+    target_id = "UpsertLoaderDummy"
+
+    join_cols = ["col1", "col2"]
+
+    data1 = [
+        (5, 6, "foo"),
+        (7, 8, "bar"),
+    ]
+    data2 = [
+        (1, 2, "baz"),
+    ]
+    data3 = [(5, 6, "boo"), (5, 7, "spam")]
+    # data5 is the merge result of data2 + data3 + data4
+    data4 = [(1, 2, "baz"), (5, 6, "boo"), (5, 7, "spam"), (7, 8, "bar")]
+
+    dummy_columns: List[str] = ["col1", "col2", "col3"]
+
+    dummy_schema = None
+    target_dh_dummy: DeltaHandle = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        Configurator().add_resource_path(extras)
+        Configurator().set_debug()
+
+        cls.target_dh_dummy = DeltaHandle.from_tc("UpsertLoaderDummy")
+
+        SparkSqlExecutor().execute_sql_file("upsertloader-test")
+
+        cls.dummy_schema = cls.target_dh_dummy.read().schema
+
+        # make sure target is empty
+        df_empty = DataframeCreator.make_partial(cls.dummy_schema, [], [])
+        cls.target_dh_dummy.overwrite(df_empty)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        DbHandle.from_tc("UpsertLoaderDb").drop_cascade()
+
+    def test_01_can_perform_incremental_on_empty(self):
+        loader = SimpleLoader(
+            handle=self.target_dh_dummy, mode="upsert", join_cols=self.join_cols
+        )
+
+        df_source = DataframeCreator.make_partial(
+            self.dummy_schema, self.dummy_columns, self.data1
+        )
+
+        loader.save(df_source)
+        self.assertDataframeMatches(self.target_dh_dummy.read(), None, self.data1)
+
+    def test_02_can_perform_incremental_append(self):
+        """The target table is already filled from before."""
+        existing_rows = self.target_dh_dummy.read().collect()
+        self.assertEqual(2, len(existing_rows))
+
+        loader = SimpleLoader(
+            handle=self.target_dh_dummy, mode="upsert", join_cols=self.join_cols
+        )
+
+        df_source = DataframeCreator.make_partial(
+            self.dummy_schema, self.dummy_columns, self.data2
+        )
+
+        loader.save(df_source)
+
+        self.assertDataframeMatches(
+            self.target_dh_dummy.read(), None, self.data1 + self.data2
+        )
+
+    def test_03_can_perform_merge(self):
+        """The target table is already filled from before."""
+        existing_rows = self.target_dh_dummy.read().collect()
+        self.assertEqual(3, len(existing_rows))
+
+        loader = SimpleLoader(
+            handle=self.target_dh_dummy, mode="upsert", join_cols=self.join_cols
+        )
+
+        df_source = DataframeCreator.make_partial(
+            self.dummy_schema, self.dummy_columns, self.data3
+        )
+
+        loader.save(df_source)
+
+        self.assertDataframeMatches(self.target_dh_dummy.read(), None, self.data4)

--- a/tests/cluster/etl/test_upsertloader.py
+++ b/tests/cluster/etl/test_upsertloader.py
@@ -1,3 +1,4 @@
+import unittest
 from typing import List
 
 from spetlrtools.testing import DataframeTestCase
@@ -10,6 +11,9 @@ from tests.cluster.delta import extras
 from tests.cluster.delta.SparkExecutor import SparkSqlExecutor
 
 
+@unittest.skip(
+    "UpsertLoader is deprecated - skipping tests...",
+)
 class UpsertLoaderTests(DataframeTestCase):
     target_id = "UpsertLoaderDummy"
 

--- a/tests/local/eh/test_ehtodeltasilver_orchestrator.py
+++ b/tests/local/eh/test_ehtodeltasilver_orchestrator.py
@@ -7,7 +7,6 @@ from spetlrtools.testing import DataframeTestCase
 from spetlr.etl import Transformer
 from spetlr.etl.extractors import IncrementalExtractor, SimpleExtractor
 from spetlr.etl.loaders import SimpleLoader
-from spetlr.etl.loaders.UpsertLoader import UpsertLoader
 from spetlr.exceptions import MissingUpsertJoinColumns
 from spetlr.orchestrators import EhToDeltaSilverOrchestrator
 from spetlr.orchestrators.ehjson2delta.EhJsonToDeltaTransformer import (
@@ -30,7 +29,7 @@ class EhToDeltaSilverOrchestratorTests(DataframeTestCase):
             with patch.object(
                 EhJsonToDeltaTransformer, "process", return_value=test_df
             ) as p1:
-                with patch.object(UpsertLoader, "save", return_value=test_df) as p2:
+                with patch.object(SimpleLoader, "save", return_value=test_df) as p2:
                     orchestrator = EhToDeltaSilverOrchestrator(
                         dh_source=dh_source_mock,
                         dh_target=dh_target_mock,
@@ -55,7 +54,7 @@ class EhToDeltaSilverOrchestratorTests(DataframeTestCase):
             with patch.object(
                 EhJsonToDeltaTransformer, "process", return_value=test_df
             ) as p1:
-                with patch.object(UpsertLoader, "save", return_value=test_df) as p2:
+                with patch.object(SimpleLoader, "save", return_value=test_df) as p2:
                     orchestrator = EhToDeltaSilverOrchestrator(
                         dh_source=dh_source_mock,
                         dh_target=dh_target_mock,
@@ -81,7 +80,7 @@ class EhToDeltaSilverOrchestratorTests(DataframeTestCase):
             with patch.object(
                 EhJsonToDeltaTransformer, "process", return_value=test_df
             ) as p1:
-                with patch.object(UpsertLoader, "save", return_value=test_df) as p2:
+                with patch.object(SimpleLoader, "save", return_value=test_df) as p2:
                     with self.assertRaises(MissingUpsertJoinColumns) as cm:
                         orchestrator = EhToDeltaSilverOrchestrator(
                             dh_source=dh_source_mock,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Refactor
- Feature

## Description

### Overview
We use handlers in SPETLR. The handlers have already `.upsert()` - this means that the `SimpleLoader` can support an easy way of using upsert by providing `mode="upsert"`.

### What is the current behavior?
In the moment, the simpleloader only support "overwrite" and "append".

https://github.com/spetlr-org/spetlr/blob/main/src/spetlr/etl/loaders/simple_loader.py

### What is the new behavior?
The simpleloader now supports upserting.


## Related Issues (Link to the open issue)
#67 

## Other
IMO it would be very great to introduce even more upsert tests. But since we use the Spark SQL engine to execute the merge, we cannot unittests it as hoped. 

