### PR TITLE
Add SlackNotifier with no stack trace

### DIFF
--- a/src/spetlr/reporting/SlackNotifier.py
+++ b/src/spetlr/reporting/SlackNotifier.py
@@ -34,7 +34,13 @@ class SlackNotifier:
         """
         self.notify_info(message=message, _hide_caller_info=True)
 
-    def notify_info(self, message: str = None, _stack_skip: int = 1, *, _hide_caller_info: bool = False):
+    def notify_info(
+        self,
+        message: str = None,
+        _stack_skip: int = 1,
+        *,
+        _hide_caller_info: bool = False,
+    ):
         """Send a notification to a webhook with the following example contents:
         "
         *A message was sent from your job <YOUR JOB NAME HERE>*

--- a/src/spetlr/reporting/SlackNotifier.py
+++ b/src/spetlr/reporting/SlackNotifier.py
@@ -22,7 +22,19 @@ class SlackNotifier:
     def add_webhook_url(self, url: str):
         self.webhookurls.append(url)
 
-    def notify_info(self, message: str = None, _stack_skip=1):
+    def notify(self, message: str):
+        """Send a notification to a webhook with the following example contents:
+        "
+        *A message was sent from your job <YOUR JOB NAME HERE>*
+
+        Sent at 2022-11-20 01:03:17
+
+        <YOUR MESSAGE HERE>
+        "
+        """
+        self.notify_info(message=message, _hide_caller_info=True)
+
+    def notify_info(self, message: str = None, _stack_skip: int = 1, *, _hide_caller_info: bool = False):
         """Send a notification to a webhook with the following example contents:
         "
         *A message was sent from your job <YOUR JOB NAME HERE>*
@@ -56,7 +68,8 @@ class SlackNotifier:
         if message:
             text += f"\n{message}\n"
 
-        text += f"\nCaller info:\n```\n{called_from}\n```\n"
+        if not _hide_caller_info:
+            text += f"\nCaller info:\n```\n{called_from}\n```\n"
 
         self._add_link_and_publish(text)
 
@@ -84,6 +97,7 @@ class SlackNotifier:
                 message="SlackNotifier.notify_exc()"
                 " was called with no active exception.",
                 _stack_skip=2,
+                _hide_caller_info=False,
             )
 
         try:

--- a/tests/cluster/reporting/test_slack_reporting.py
+++ b/tests/cluster/reporting/test_slack_reporting.py
@@ -72,7 +72,9 @@ class SlackNotifierTests(unittest.TestCase):
             self.HTTPHandler.called_data["text"],
             "message was sent from your job Testing Run",
         )
-        self.assertRegex(self.HTTPHandler.called_data["text"], "test_02_notify_info_webhook")
+        self.assertRegex(
+            self.HTTPHandler.called_data["text"], "test_02_notify_info_webhook"
+        )
         self.assertRegex(self.HTTPHandler.called_data["text"], "my nice info message")
         print(self.HTTPHandler.called_data["text"])
 
@@ -91,5 +93,7 @@ class SlackNotifierTests(unittest.TestCase):
             self.HTTPHandler.called_data["text"],
             "exception has occurred in your job Testing Run",
         )
-        self.assertRegex(self.HTTPHandler.called_data["text"], "test_03_notify_exc_webhook")
+        self.assertRegex(
+            self.HTTPHandler.called_data["text"], "test_03_notify_exc_webhook"
+        )
         print(self.HTTPHandler.called_data["text"])

--- a/tests/cluster/reporting/test_slack_reporting.py
+++ b/tests/cluster/reporting/test_slack_reporting.py
@@ -45,11 +45,11 @@ class SlackNotifierTests(unittest.TestCase):
         self.HTTPHandler.called = False
         self.HTTPHandler.called_data = {}
 
-    def test_01_info_webhook(self):
+    def test_01_notify_webhook(self):
         slack = SlackNotifier(self.hook_url)
 
         # Call the WebHookNotifier here
-        slack.notify_info("my nice message")
+        slack.notify("my nice message")
 
         self.assertTrue(self.HTTPHandler.called)
         self.assertIn("text", self.HTTPHandler.called_data)
@@ -57,11 +57,26 @@ class SlackNotifierTests(unittest.TestCase):
             self.HTTPHandler.called_data["text"],
             "message was sent from your job Testing Run",
         )
-        self.assertRegex(self.HTTPHandler.called_data["text"], "test_01_info_webhook")
         self.assertRegex(self.HTTPHandler.called_data["text"], "my nice message")
         print(self.HTTPHandler.called_data["text"])
 
-    def test_02_exc_webhook(self):
+    def test_02_notify_info_webhook(self):
+        slack = SlackNotifier(self.hook_url)
+
+        # Call the WebHookNotifier here
+        slack.notify_info("my nice info message")
+
+        self.assertTrue(self.HTTPHandler.called)
+        self.assertIn("text", self.HTTPHandler.called_data)
+        self.assertRegex(
+            self.HTTPHandler.called_data["text"],
+            "message was sent from your job Testing Run",
+        )
+        self.assertRegex(self.HTTPHandler.called_data["text"], "test_02_notify_info_webhook")
+        self.assertRegex(self.HTTPHandler.called_data["text"], "my nice info message")
+        print(self.HTTPHandler.called_data["text"])
+
+    def test_03_notify_exc_webhook(self):
         slack = SlackNotifier(self.hook_url)
 
         try:
@@ -76,5 +91,5 @@ class SlackNotifierTests(unittest.TestCase):
             self.HTTPHandler.called_data["text"],
             "exception has occurred in your job Testing Run",
         )
-        self.assertRegex(self.HTTPHandler.called_data["text"], "test_02_exc_webhook")
+        self.assertRegex(self.HTTPHandler.called_data["text"], "test_03_notify_exc_webhook")
         print(self.HTTPHandler.called_data["text"])

--- a/tests/local/reporting/test_slack_reporting.py
+++ b/tests/local/reporting/test_slack_reporting.py
@@ -45,21 +45,34 @@ class SlackNotifierTests(unittest.TestCase):
         self.HTTPHandler.called = False
         self.HTTPHandler.called_data = {}
 
-    def test_01_info_webhook(self):
+    def test_01_notify_webhook(self):
         slack = SlackNotifier(self.hook_url)
 
-        slack.notify_info("my nice message")
+        slack.notify("my nice message")
 
         self.assertTrue(self.HTTPHandler.called)
         self.assertIn("text", self.HTTPHandler.called_data)
         self.assertRegex(
             self.HTTPHandler.called_data["text"], "message was sent from databricks"
         )
-        self.assertRegex(self.HTTPHandler.called_data["text"], "test_01_info_webhook")
         self.assertRegex(self.HTTPHandler.called_data["text"], "my nice message")
         print(self.HTTPHandler.called_data["text"])
 
-    def test_02_exc_webhook(self):
+    def test_02_notify_info_webhook(self):
+        slack = SlackNotifier(self.hook_url)
+
+        slack.notify_info("my nice info message")
+
+        self.assertTrue(self.HTTPHandler.called)
+        self.assertIn("text", self.HTTPHandler.called_data)
+        self.assertRegex(
+            self.HTTPHandler.called_data["text"], "message was sent from databricks"
+        )
+        self.assertRegex(self.HTTPHandler.called_data["text"], "test_02_notify_info_webhook")
+        self.assertRegex(self.HTTPHandler.called_data["text"], "my nice info message")
+        print(self.HTTPHandler.called_data["text"])
+
+    def test_03_notify_exc_webhook(self):
         slack = SlackNotifier(self.hook_url)
 
         try:
@@ -74,5 +87,5 @@ class SlackNotifierTests(unittest.TestCase):
             self.HTTPHandler.called_data["text"],
             "An exception has occurred in databricks",
         )
-        self.assertRegex(self.HTTPHandler.called_data["text"], "test_02_exc_webhook")
+        self.assertRegex(self.HTTPHandler.called_data["text"], "test_03_notify_exc_webhook")
         print(self.HTTPHandler.called_data["text"])

--- a/tests/local/reporting/test_slack_reporting.py
+++ b/tests/local/reporting/test_slack_reporting.py
@@ -68,7 +68,9 @@ class SlackNotifierTests(unittest.TestCase):
         self.assertRegex(
             self.HTTPHandler.called_data["text"], "message was sent from databricks"
         )
-        self.assertRegex(self.HTTPHandler.called_data["text"], "test_02_notify_info_webhook")
+        self.assertRegex(
+            self.HTTPHandler.called_data["text"], "test_02_notify_info_webhook"
+        )
         self.assertRegex(self.HTTPHandler.called_data["text"], "my nice info message")
         print(self.HTTPHandler.called_data["text"])
 
@@ -87,5 +89,7 @@ class SlackNotifierTests(unittest.TestCase):
             self.HTTPHandler.called_data["text"],
             "An exception has occurred in databricks",
         )
-        self.assertRegex(self.HTTPHandler.called_data["text"], "test_03_notify_exc_webhook")
+        self.assertRegex(
+            self.HTTPHandler.called_data["text"], "test_03_notify_exc_webhook"
+        )
         print(self.HTTPHandler.called_data["text"])


### PR DESCRIPTION
## What type of PR is this?
- Feature

## Description
The SlackNotifier class has a new method named "notify" which works similar to "notify_info" except that it does not show stack trace.

### Overview
The SlackNotifier  class and its corresponding unit tests were modified.

### What is the new behavior?
The SlackNotifier class has a new method named "notify" which works similar to "notify_info" except that it does not show stack trace.

### Does this PR introduce a breaking change?
No. The current API can be used as it was.
