### PR TITLE
ensure ability to control managed table

### DIFF
--- a/src/spetlr/deltaspec/DeltaTableSpecBase.py
+++ b/src/spetlr/deltaspec/DeltaTableSpecBase.py
@@ -42,6 +42,16 @@ class DeltaTableSpecBase:
 
         self.name = ensureStr(self.name)
         self.location = ensureStr(self.location)
+
+        if (
+            (self.name and not self.name.startswith("delta.`"))  # a real name
+            and self.location
+            and self.location.startswith("dbfs:/user/hive/")
+        ):
+            # managed table locations start with this string.
+            # we should treat this like an unspecified location
+            self.location = None
+
         self.comment = ensureStr(self.comment)
 
         if self.name and "{" not in self.name:

--- a/tests/cluster/delta/deltaspec/tables.py
+++ b/tests/cluster/delta/deltaspec/tables.py
@@ -95,3 +95,16 @@ newlocation = DeltaTableSpec.from_sql(
     LOCATION "/tmp/somewhere{ID}/locchange/new"
     """
 )
+
+managed = DeltaTableSpec.from_sql(
+    """
+    CREATE TABLE myDeltaTableSpecTestDb{ID}.manged
+    (
+        b string,
+        c double,
+        d string
+    )
+    USING DELTA
+    COMMENT "Contains useful data"
+    """
+)

--- a/tests/cluster/delta/deltaspec/test_tblspec.py
+++ b/tests/cluster/delta/deltaspec/test_tblspec.py
@@ -97,3 +97,9 @@ class TestTableSpec(DataframeTestCase):
         diff = tables.newname.compare_to_name()
         self.assertTrue(diff.complete_match(), diff)
         self.assertEqual(tables.newname.get_dh().read().count(), 1)
+
+    def test_04_can_control_managed_table(self):
+        tables.managed.make_storage_match(allow_table_create=True)
+
+        diff = tables.managed.compare_to_name()
+        self.assertTrue(diff.complete_match(), diff)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- Bug Fix

## Description
Managed tables actually have a location when described by spark. Blinding the DeltaTableSpec to managed locations makes the description match the create statement.

This fixes a bug where a managed table DeltaTableSpec did not compare equal to its named table after creation.
