### PR TITLE
Modify legacy tables.

### DIFF
--- a/src/spetlr/deltaspec/DeltaTableSpec.py
+++ b/src/spetlr/deltaspec/DeltaTableSpec.py
@@ -47,7 +47,13 @@ class DeltaTableSpec(DeltaTableSpecBase):
 
         init_args = {k: v for k, v in init_args.items() if v}
 
-        return cls(**init_args)
+        o = cls(**init_args)
+
+        # objects initialized from parsed SQL should have these set
+        # so that we define capable tables.
+        o.set_good_defaults()
+
+        return o
 
     @classmethod
     def from_path(cls, location: str) -> "DeltaTableSpec":
@@ -74,7 +80,13 @@ class DeltaTableSpec(DeltaTableSpecBase):
 
         init_args = {k: v for k, v in init_args.items() if v}
 
-        return cls(**init_args)
+        o = cls(**init_args)
+
+        # objects initialized from parsed SQL should have these set
+        # so that we define capable tables.
+        o.set_good_defaults()
+
+        return o
 
     @classmethod
     def from_name(cls, in_name: str) -> "DeltaTableSpec":

--- a/src/spetlr/deltaspec/DeltaTableSpecDifference.py
+++ b/src/spetlr/deltaspec/DeltaTableSpecDifference.py
@@ -411,6 +411,11 @@ class DeltaTableSpecDifference:
                     )
 
         statements = []
+
+        # some table properties are needed to be able to drop columns.
+        # therefore we need to set those first.
+        statements += full_diff._tblproperties_alter_statements()
+
         statements += full_diff._schema_alter_statements(
             allow_columns_add=allow_columns_add,
             allow_columns_drop=allow_columns_drop,
@@ -423,8 +428,6 @@ class DeltaTableSpecDifference:
             statements.append(
                 f"""COMMENT ON TABLE {base.name} is {json.dumps(target.comment)}"""
             )
-
-        statements += full_diff._tblproperties_alter_statements()
 
         # Change the name last so that we can still refer to the base name above this
         if base.name != target.name:

--- a/tests/cluster/delta/deltaspec/tables.py
+++ b/tests/cluster/delta/deltaspec/tables.py
@@ -108,3 +108,23 @@ managed = DeltaTableSpec.from_sql(
     COMMENT "Contains useful data"
     """
 )
+
+simple_create_sql = """
+    CREATE TABLE myDeltaTableSpecTestDb{ID}.direct
+    (
+        b string,
+        c double,
+        d string
+    )
+    USING DELTA
+"""
+
+
+simple_modified_sql = """
+    CREATE TABLE myDeltaTableSpecTestDb{ID}.direct
+    (
+        b string,
+        c double
+    )
+    USING DELTA
+"""

--- a/tests/cluster/delta/deltaspec/test_tblspec.py
+++ b/tests/cluster/delta/deltaspec/test_tblspec.py
@@ -3,6 +3,7 @@ import unittest
 from spetlrtools.testing import DataframeTestCase
 
 from spetlr import Configurator
+from spetlr.deltaspec import DeltaTableSpec
 from spetlr.spark import Spark
 from tests.cluster.delta.deltaspec import tables
 
@@ -102,4 +103,16 @@ class TestTableSpec(DataframeTestCase):
         tables.managed.make_storage_match(allow_table_create=True)
 
         diff = tables.managed.compare_to_name()
+        self.assertTrue(diff.complete_match(), diff)
+
+    def test_05_modify_to_allow_drop(self):
+        # a table has been created without the DeltaTableSpec:
+        spark = Spark.get()
+        spark.sql(tables.simple_create_sql.format(**Configurator().get_all_details()))
+
+        # now a modified version is to be applied that drops columns:
+        ds = DeltaTableSpec.from_sql(tables.simple_modified_sql)
+        ds.make_storage_match(allow_columns_drop=True)
+
+        diff = ds.compare_to_name()
         self.assertTrue(diff.complete_match(), diff)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Bug Fix

## Description
Previously the DeltaTableSpec default initalized the tableproperties to the values that are useful and necessary for column operations. This blinded it to the case that real tables may not have them. This new PR corrects this behavior. Now, only when we read the specification from SQL do we assume that the good values are desired. In all other cases we simply accept the given values.

In a way this makes a SQL initalized DeltaTableSpec more powerful than a default-initalized instance. Therefore the setting of the good defaults is exposed as a method available to the library user.
