### PR TITLE
feat: enable unity catalog

### DIFF
--- a/.github/deploy-bicep/main.bicep
+++ b/.github/deploy-bicep/main.bicep
@@ -23,6 +23,7 @@ param sqlServerAdminPassword string
 param sqlAdminSpnName string
 param sqlAdminObjectId string
 param logAnalyticsWsName string
+param databricksAccessConnectorName string
 
 // Metastore resources
 param metastoreDatabricksName string
@@ -94,5 +95,6 @@ module resources2 'resources-integration.bicep' = {
     sqlAdminSpnName: sqlAdminSpnName
     sqlAdminObjectId: sqlAdminObjectId
     logAnalyticsWsName: logAnalyticsWsName
+    databricksAccessConnectorName: databricksAccessConnectorName
   }
 }

--- a/.github/deploy-bicep/resources-integration.bicep
+++ b/.github/deploy-bicep/resources-integration.bicep
@@ -15,6 +15,7 @@ param sqlServerAdminPassword string
 param sqlAdminSpnName string
 param sqlAdminObjectId string
 param logAnalyticsWsName string
+param databricksAccessConnectorName string
 
 //#############################################################################################
 //# Provision Databricks Workspace
@@ -27,6 +28,20 @@ resource rsdatabricks 'Microsoft.Databricks/workspaces@2022-04-01-preview' = {
     managedResourceGroupId: subscriptionResourceId('Microsoft.Resources/resourceGroups', '${resourceGroupName}Cluster')
   }
   tags: resourceTags
+}
+
+
+//#############################################################################################
+//# Provision Databricks Access Connector
+//#############################################################################################
+
+resource databricksAccessConnector 'Microsoft.Databricks/accessConnectors@2023-05-01' = {
+  name: databricksAccessConnectorName
+  location: location
+  tags: resourceTags
+  identity: {
+    type: 'SystemAssigned'
+  }
 }
 
 //#############################################################################################

--- a/.github/deploy/destroy.ps1
+++ b/.github/deploy/destroy.ps1
@@ -30,5 +30,11 @@ Write-Host "  Now Destroying Parent Resource Group!" -ForegroundColor Red
 
 az group delete --name $resourceGroupName --yes --no-wait
 
+
 Write-Host "  Parent Resource Group Deleted" -ForegroundColor Green
 
+Write-Host "  Now Destroying Databricks Catalog: $databricksCatalogName !" -ForegroundColor Red
+
+databricks unity-catalog catalogs delete --name $databricksCatalogName -purge
+
+Write-Host "  Catalog deleted" -ForegroundColor Green

--- a/.github/deploy/steps/00-Config.ps1
+++ b/.github/deploy/steps/00-Config.ps1
@@ -25,6 +25,7 @@ $databricksName               = $resourceName
 $dataLakeName                 = $resourceName
 $databaseServerName           = $resourceName + "test"
 $deliveryDatabase             = "Delivery"
+$databricksCatalogName           = $resourceName
 
 
 $sqlServerAdminUser           = "DataPlatformAdmin"

--- a/.github/deploy/steps/85-Create-And-Connect-Metastore.ps1
+++ b/.github/deploy/steps/85-Create-And-Connect-Metastore.ps1
@@ -9,7 +9,7 @@
 # 7. Add storage credential to metastore
 # 8. Create catalog
 ###############################################################################################
-Write-Host "Creating and connecting metastore '$metastoreName' for Databricks workspace '$databricksName'" -ForegroundColor Green
+Write-Host "Creating and connecting metastore '$metastoreName' for Databricks workspace '$metastoreDatabricksName'" -ForegroundColor Green
 
 Write-Host "Get resource information: Metastore Storage Account, Access Connector, Metastore Databricks Workspace" -ForegroundColor DarkYellow
 $metastoreStorageAccount = az storage account show `

--- a/.github/deploy/steps/86-Enable-Workspace-UnityCatalog.ps1
+++ b/.github/deploy/steps/86-Enable-Workspace-UnityCatalog.ps1
@@ -1,0 +1,101 @@
+# THis replicates almost 1-1 the 85-create-and-connect-metastore.ps1
+# $metastoreStorageAccount is already saved from previous script
+# $metastoreid is already saved from precious script
+
+
+Write-Host "Connecting metastore '$metastoreName' for Databricks workspace '$databricksName'" -ForegroundColor Green
+
+$thisAccessConnector = az databricks access-connector show `
+    --resource-group $resourceGroupName `
+    --name $databricksAccessConnectorName `
+| ConvertFrom-Json
+Throw-WhenError -output $thisAccessConnector
+
+
+$thisDatabricks = az databricks workspace show `
+    --resource-group $resourceGroupName `
+    --name $databricksName `
+| ConvertFrom-Json
+Throw-WhenError -output $thisDatabricks
+
+
+Write-Host "Set contributer role for access connector $databricksAccessConnectorName" -ForegroundColor DarkYellow
+$output = az role assignment create `
+    --assignee $thisAccessConnector.identity.principalId `
+    --role "Storage Blob Data Contributor" `
+    --scope $metastoreStorageAccount.id
+Throw-WhenError -output $output
+
+
+
+Write-Host "Connect to Metastore Databricks Workspace. Setting SPN as admin and getting token." -ForegroundColor DarkYellow
+
+. $PSScriptRoot/15-ensure-keyvault-access.ps1
+$cicdSpn = Get-SpnWithSecret -spnName $cicdSpnName -keyVaultName $keyVaultName
+Throw-WhenError -output $cicdSpn
+
+$thisBearerToken = Set-DatabricksSpnAdminUser `
+    -tenantId $tenantId `
+    -clientId $cicdSpn.clientId `
+    -clientSecret $cicdSpn.secretText `
+    -workspaceUrl $thisDatabricks.workspaceUrl `
+    -resourceId $thisDatabricks.id
+Throw-WhenError -output $thisBearerToken
+
+$thisDatabricksToken = ConvertTo-DatabricksPersonalAccessToken `
+    -workspaceUrl $thisDatabricks.workspaceUrl `
+    -bearerToken $thisBearerToken
+Throw-WhenError -output $thisDatabricksToken
+
+[Environment]::SetEnvironmentVariable('DATABRICKS_AAD_TOKEN', $thisDatabricksToken)
+
+$thisDatabricksUrlHttps = "https://" + $thisDatabricks.workspaceUrl
+$output = databricks configure --host $thisDatabricksUrlHttps --aad-token
+Throw-WhenError -output $output
+
+
+Write-Host "Assignning workspace to metastore..."
+$output = databricks unity-catalog metastores assign `
+    --workspace-id $thisDatabricks.workspaceId `
+    --metastore-id $metastoreId
+Throw-WhenError -output $output
+
+
+
+Write-Host "Add storage credential for access connector for workspace. Check if the workspace contains the storage credential." -ForegroundColor DarkYellow
+# For the metastore to have access to the access connector, a credential must be added to the workspace,
+# and then the metastore can grab this credential and use it
+$storageCredentials = databricks unity-catalog storage-credentials list | ConvertFrom-Json
+Throw-WhenError -output $storageCredentials
+
+if ($storageCredentials.storage_credentials.name -contains $databricksAccessConnectorName) {
+    Write-Host "Does contain. Geting credential id..."
+    $accessConnectorCredentialId = ($storageCredentials.storage_credentials | Where-Object { $_.name -eq $databricksAccessConnectorName }).id
+}
+else {
+    Write-Host "Does NOT contain. Creating and get id..."
+    $accessConnectorCredential = databricks unity-catalog storage-credentials create `
+        --name $databricksAccessConnectorName `
+        --az-mi-access-connector-id $databricksAccessConnectorName.id `
+    | ConvertFrom-Json
+    Throw-WhenError -output $accessConnectorCredential
+    $accessConnectorCredentialId = $accessConnectorCredential.id
+}
+
+
+#Write-Host "Add/update storage credential to metastore" -ForegroundColor DarkYellow
+#$output = databricks unity-catalog metastores update `
+#  --id $metastoreId `
+#  --storage-root-credential-id $accessConnectorCredentialId
+#Throw-WhenError -output $output
+
+
+if ($catalogs.catalogs.name -contains $databricksCatalogName) {
+    Write-Host "Catalog exists"
+}
+else {
+    Write-Host "Catalog does not exist. Creating..."
+    $output = databricks unity-catalog catalogs create `
+        --name $databricksCatalogName
+    Throw-WhenError -output $output
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- Feature
- Deployment (Azure, CI/CD, PowerShell, ...)


## Description

### Overview
This PR enables unity catalog for the PR pipeline. This means, that the SPETLR tests that is runned - is runned within a Unity Catalog activated workspace. 

### What is the current behavior?
In the moment, a metastore is existing. But the workspace that tests SPETLR has not UC enabled. 

### What is the new behavior?
The PR databricks workspace is UC enabled

### Does this PR introduce a breaking change?
Yes - it is expected that some SPETLR code will fail. It could be:

* table handle three dots to table (catalog.schema.table)
* Accessing using tablehandle location
* mounts vs. external locations
* ...

Therefore, this PR will also introduce changes to the SPETLR code. 
I will be assesed how backwardcompatible spetlr is regarding UC vs. non-UC workspaces. 
