### PR TITLE
allow configuration from view

### DIFF
--- a/src/spetlr/configurator/sql/create.py
+++ b/src/spetlr/configurator/sql/create.py
@@ -6,6 +6,7 @@ from more_itertools import peekable
 from spetlr.configurator.sql.db import _walk_db_statement
 from spetlr.configurator.sql.table import _walk_table_statement
 from spetlr.configurator.sql.utils import _meaningful_token_iter
+from spetlr.configurator.sql.view import _walk_view_statement
 
 
 def _walk_create_statement(statement: sqlparse.sql.Statement) -> Dict:
@@ -16,19 +17,30 @@ def _walk_create_statement(statement: sqlparse.sql.Statement) -> Dict:
     # We are now ready to go through the statement
     # both create Table and create database must start with create
     token = next(statement)
-    if token.value.upper() != "CREATE":
-        # not a table or db create statement. Nothing to do
+    if token.value.upper() not in ("CREATE", "CREATE OR REPLACE"):
+        # not a create statement. Nothing to do
         return {}
 
-    entity = next(statement)
-
-    if entity.value.upper() == "TABLE":
-        is_table = True
-    elif entity.value.upper() in ("SCHEMA", "DATABASE"):
-        is_table = False
-    else:
-        # not a table or db create statement. Nothing to do
-        return {}
+    is_table = False
+    is_db = False
+    is_view = False
+    while True:
+        entity = next(statement)
+        if entity.value.upper() == "TABLE":
+            is_table = True
+            break
+        elif entity.value.upper() in ("SCHEMA", "DATABASE"):
+            is_db = True
+            break
+        elif entity.value.upper() in ("VIEW",):
+            is_view = True
+            break
+        elif entity.value.upper() in ("TEMPORARY",):
+            # simply ignored
+            continue
+        else:
+            # not a table or db create statement. Nothing to do
+            return {}
 
     # next is the optional "IF NOT EXISTS"
     if statement.peek().value.upper() == "IF NOT EXISTS":
@@ -36,5 +48,9 @@ def _walk_create_statement(statement: sqlparse.sql.Statement) -> Dict:
 
     if is_table:
         return _walk_table_statement(statement)
-    else:
+    if is_db:
         return _walk_db_statement(statement)
+    if is_view:
+        return _walk_view_statement(statement)
+
+    raise Exception("unreachable code point")

--- a/src/spetlr/configurator/sql/view.py
+++ b/src/spetlr/configurator/sql/view.py
@@ -1,0 +1,25 @@
+from typing import Dict
+
+from spetlr.configurator.sql.types import _PeekableTokenList
+
+
+def _walk_view_statement(statement: _PeekableTokenList) -> Dict:
+    # for views, we only collect the name.
+    name_parts = []
+    while True:
+        # until we managed to unpack the AS SELECT statement,
+        # all the bits must be part of the name.
+        # This allows unpacking names like CREATE VIEW {MYDB}.tbl{ID}
+        # which will return lots of parsing errors otherwise.
+
+        name_parts.append(next(statement).value.strip("`"))
+
+        peeked = str(statement.peek()).strip().upper()
+        if peeked.startswith(("AS", "(", "COMMENT", "TBLPROPERTIES")):
+            break
+        else:
+            continue
+
+    object_details = {"name": "".join(name_parts), "_is_view": True}
+
+    return object_details

--- a/tests/local/configurator/test_configurator.py
+++ b/tests/local/configurator/test_configurator.py
@@ -7,7 +7,15 @@ from spetlr import Configurator
 from spetlr.schema_manager import SchemaManager
 from spetlr.schema_manager.spark_schema import get_schema
 from spetlr.sql import SqlExecutor
-from tests.local.configurator import sql, tables1, tables2, tables3, tables4, tables5
+from tests.local.configurator import (
+    sql,
+    tables1,
+    tables2,
+    tables3,
+    tables4,
+    tables5,
+    views,
+)
 
 
 class TestConfigurator(unittest.TestCase):
@@ -238,3 +246,9 @@ class TestConfigurator(unittest.TestCase):
         # recover  key
         key = c.key_of("name", "anotherName")
         self.assertEqual(c.get(key, "path"), "/somewhere")
+
+    def test_14_views(self):
+        c = Configurator()
+        c.add_sql_resource_path(views)
+
+        self.assertEqual(c.get("MyViewId", "name"), "SomeViewName")

--- a/tests/local/configurator/views/view.sql
+++ b/tests/local/configurator/views/view.sql
@@ -1,0 +1,6 @@
+-- SPETLR.CONFIGURATOR key: MyViewId
+CREATE OR REPLACE TEMPORARY VIEW IF NOT EXISTS SomeViewName
+--   (today COMMENT 'right now') This construct is not currenly supported.
+COMMENT 'Better than a clock'
+TBLPROPERTIES ('m.prop'='hello')
+AS SELECT current_date();


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Feature

## Description
The configurators ability to parse SQL statements is extended to include the ability to parse CREATE VIEW statements. 
For now, only the name can be extracted.
