### PR TITLE
try relaxing the version requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,12 @@ install_requires =
     timezonefinder==6.0.2
     more_itertools
     pycountry
-    numpy<=1.24 # Numpy does not support 3.8 if above 1.24
     databricks-sdk
-    urllib3==1.26.16
+    # Numpy does not support 3.8 if above 1.24
+    numpy<=1.24;python_version<="3.8"
+    numpy;python_version>"3.8"
+    urllib3==1.26.16;python_version<="3.8" # follows numpy
+    urllib3;python_version>"3.8" # follows numpy
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Optimization

## Description
Relaxing the version requirements for higher python versions should be ok since the limitation came from python 3.8 vs. numpy.
I am having versioning conflicts and this will hopefully help with that.
