### PR TITLE
support generated and default expressions in schema

### DIFF
--- a/src/spetlr/configurator/sql/StatementBlocks.py
+++ b/src/spetlr/configurator/sql/StatementBlocks.py
@@ -21,7 +21,7 @@ class ClusteredBy:
 @dataclass
 class StatementBlocks:
     schema: str = None
-    using: str = None
+    using: str = "DELTA"
     options: Dict[str, str] = None
     partitioned_by: List[str] = None
     clustered_by: ClusteredBy = None

--- a/src/spetlr/configurator/sql/table.py
+++ b/src/spetlr/configurator/sql/table.py
@@ -61,13 +61,6 @@ def _extract_table_blocks(stmt: _PeekableTokenList) -> StatementBlocks:
     else:
         raise _UnpackAttemptFailed("No valid table schema")
 
-    token = next(stmt)
-    val = token.value.upper()
-    if val == "USING":
-        blocks.using = next(stmt).value
-    else:
-        raise SpetlrConfiguratorInvalidSqlException("No valid table data source")
-
     for token in stmt:
         val = token.value.upper()
 
@@ -75,6 +68,10 @@ def _extract_table_blocks(stmt: _PeekableTokenList) -> StatementBlocks:
             blocks.options = {}
             for k, v in _unpack_options(stmt):
                 blocks.options[k] = v
+            continue
+
+        if val == "USING":
+            blocks.using = next(stmt).value
             continue
 
         if re.match(r"PARTITIONED\s+BY", val):

--- a/tests/local/delta/sql/tables.sql
+++ b/tests/local/delta/sql/tables.sql
@@ -11,3 +11,12 @@ b string
 )
 USING DELTA
 LOCATION '/{MNT}/foo/bar';
+
+-- SPETLR.CONFIGURATOR key: Table3
+CREATE TABLE IF NOT EXISTS rectangles
+(
+  id BIGINT GENERATED ALWAYS AS IDENTITY,
+  a INT,
+  b INT,
+  area INT GENERATED ALWAYS AS (a * b)
+);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Feature

## Description

- Support Generated and default expressions in sql parsing for detla table spec.
- Added a new `ignore()` method to the DeltaTableSpecDifference to simplify comparisons that focus on f.ex. schema.
