### PR TITLE
Throw an exception in SqlExecutor if no files found

### DIFF
--- a/src/spetlr/sql/SqlExecutor.py
+++ b/src/spetlr/sql/SqlExecutor.py
@@ -22,6 +22,8 @@ class SqlExecutor:
         base_module: Union[str, ModuleType] = None,
         server: BaseExecutor = None,
         statement_spliter: Optional[List[str]] = _DEFAULT,
+        *,
+        ignore_empty_folder: bool = False,
     ):
         """Class to pre-treat sql statements and execute them.
         Replacement sequenced related to the Configurator will be inserted before
@@ -41,6 +43,7 @@ class SqlExecutor:
             # We treat it as another way to end a statement
             statement_spliter = [";", "-- COMMAND ----------"]
         self.statement_spliter = statement_spliter
+        self.ignore_empty_folder = ignore_empty_folder
 
     def _wildcard_string_to_regexp(self, instr: str) -> str:
         # prepare file pattern:
@@ -171,7 +174,7 @@ class SqlExecutor:
                 with open(file_path) as file:
                     yield file.read()
 
-        if not found:
+        if not found and not self.ignore_empty_folder:
             raise ValueError(f"No matching .sql files found in '{self.base_module}'")
 
     def execute_sql_file(self, file_pattern: str, exclude_pattern: str = None):

--- a/src/spetlr/sql/SqlExecutor.py
+++ b/src/spetlr/sql/SqlExecutor.py
@@ -151,6 +151,7 @@ class SqlExecutor:
         if exclude_pattern is not None:
             exclude_pattern = self._wildcard_string_to_regexp(exclude_pattern)
 
+        found = False
         # loop the module contents and find matching files
         for file_name in ir.contents(self.base_module):
             extension = Path(file_name).suffix
@@ -165,9 +166,13 @@ class SqlExecutor:
             ):
                 continue
 
+            found = True
             with ir.path(self.base_module, file_name) as file_path:
                 with open(file_path) as file:
                     yield file.read()
+
+        if not found:
+            raise ValueError(f"No matching .sql files found in '{self.base_module}'")
 
     def execute_sql_file(self, file_pattern: str, exclude_pattern: str = None):
         """

--- a/tests/local/sql/test_SqlExecutor.py
+++ b/tests/local/sql/test_SqlExecutor.py
@@ -29,3 +29,8 @@ class TestSqlExecutor(unittest.TestCase):
         with self.assertRaises(ValueError):
             s = SqlExecutor(sql, statement_spliter=None)
             statements = list(s.get_statements("unknown"))
+
+    def test_06_file_not_found_and_ignore_empty_folder(self):
+        s = SqlExecutor(sql, statement_spliter=None, ignore_empty_folder=True)
+        statements = list(s.get_statements("unknown"))
+        self.assertEqual(len(statements), 0)

--- a/tests/local/sql/test_SqlExecutor.py
+++ b/tests/local/sql/test_SqlExecutor.py
@@ -19,3 +19,13 @@ class TestSqlExecutor(unittest.TestCase):
         s = SqlExecutor(sql, statement_spliter=None)
         statements = list(s.get_statements("*"))
         self.assertEqual(len(statements), 1)
+
+    def test_04_file_by_name(self):
+        s = SqlExecutor(sql, statement_spliter=None)
+        statements = list(s.get_statements("test1"))
+        self.assertEqual(len(statements), 1)
+
+    def test_05_file_not_found(self):
+        with self.assertRaises(ValueError):
+            s = SqlExecutor(sql, statement_spliter=None)
+            statements = list(s.get_statements("unknown"))

--- a/tests/local/sql/test_SqlExecutor.py
+++ b/tests/local/sql/test_SqlExecutor.py
@@ -28,7 +28,7 @@ class TestSqlExecutor(unittest.TestCase):
     def test_05_file_not_found(self):
         with self.assertRaises(ValueError):
             s = SqlExecutor(sql, statement_spliter=None)
-            statements = list(s.get_statements("unknown"))
+            list(s.get_statements("unknown"))
 
     def test_06_file_not_found_and_ignore_empty_folder(self):
         s = SqlExecutor(sql, statement_spliter=None, ignore_empty_folder=True)


### PR DESCRIPTION
## What type of PR is this?
- Feature

## Description
The sql file execution in:

   SqlExecutor(base_module).**execute_sql_file**(file_pattern)

should throw an exception if no .sql files are found in the base_module folder and the specified file_pattern. 
The reason for it is to detect spelling errors in the file or pattern name or choosing the wrong base_module folder by mistake.

### Overview
        if not found:
            raise ValueError(f"No matching .sql files found in '{self.base_module}'")

### What is the current behavior?
No exception was thrown until now. The method did simply nothing.

### What is the new behavior?
A ValueError exception is thrown.

### Does this PR introduce a breaking change?
There is a potential breaking change if people relied on empty folders being ignored. There is a new parameter that will accomplish the same:
SqlExecutor(base_module, **ignore_empty_folder=True**).execute_sql_file(file_pattern)
