### PR TITLE
Feature/support null and default

### DIFF
--- a/src/spetlr/configurator/_cli/bformat.py
+++ b/src/spetlr/configurator/_cli/bformat.py
@@ -1,0 +1,10 @@
+def bformat(input: str) -> str:
+    """Format the input python code with black if
+    black is installed. If it is not installed, just
+    return the input."""
+    try:
+        import black
+
+        return black.format_file_contents(input, fast=False, mode=black.FileMode())
+    except ModuleNotFoundError:
+        return input

--- a/src/spetlr/configurator/_cli/generate_keys_file.py
+++ b/src/spetlr/configurator/_cli/generate_keys_file.py
@@ -1,6 +1,7 @@
 import argparse
 import os.path
 
+from spetlr.configurator._cli.bformat import bformat
 from spetlr.exceptions.cli_exceptions import SpetlrCliCheckFailed
 
 
@@ -34,14 +35,7 @@ def generate_keys_file(options):
     )
 
     # if black is installed, use it to format the contents
-    try:
-        import black
-
-        new_conts = black.format_file_contents(
-            new_conts, fast=False, mode=black.FileMode()
-        )
-    except ModuleNotFoundError:
-        pass
+    new_conts = bformat(new_conts)
 
     output_file = options.output_file or ""
     output_file = output_file.replace("\\", "/")

--- a/src/spetlr/deltaspec/DeltaTableSpec.py
+++ b/src/spetlr/deltaspec/DeltaTableSpec.py
@@ -1,14 +1,10 @@
-import pyspark.sql.types
 from pyspark.sql import DataFrame
 from pyspark.sql.utils import AnalysisException
 
 from spetlr import Configurator
 from spetlr.configurator.sql.parse_sql import parse_single_sql_statement
 from spetlr.delta import DeltaHandle
-from spetlr.deltaspec.DeltaTableSpecBase import (
-    DeltaTableSpecBase,
-    _DEFAULT_blankedPropertyKeys,
-)
+from spetlr.deltaspec.DeltaTableSpecBase import DeltaTableSpecBase
 from spetlr.deltaspec.DeltaTableSpecDifference import DeltaTableSpecDifference
 from spetlr.deltaspec.exceptions import (
     InvalidSpecificationError,
@@ -17,7 +13,6 @@ from spetlr.deltaspec.exceptions import (
 )
 from spetlr.schema_manager.spark_schema import get_schema
 from spetlr.spark import Spark
-from spetlr.sqlrepr.sql_types import repr_sql_types
 
 
 class DeltaTableSpec(DeltaTableSpecBase):
@@ -112,42 +107,6 @@ class DeltaTableSpec(DeltaTableSpecBase):
             location=details["location"],
             comment=details["description"],
         )
-
-    # String representations
-
-    def __repr__(self):
-        """Return a correct and minimal string,
-         that can be evaluated as python code to return a DeltaTableSpec instance
-        that will compare equal to the current instance."""
-        parts = [
-            (f"name={repr(self.name)}"),
-            f"schema={repr_sql_types(self.schema)}",
-            (f"options={repr(self.options)}" if self.options else ""),
-            (
-                f"partitioned_by={repr(self.partitioned_by)}"
-                if self.partitioned_by
-                else ""
-            ),
-            (f"tblproperties={repr(self.tblproperties)}" if self.tblproperties else ""),
-            (f"comment={repr(self.comment)}" if self.comment else ""),
-            (f"location={repr(self.location)}" if self.location else ""),
-            (
-                f"blankedPropertyKeys={repr(self.blankedPropertyKeys)}"
-                if self.blankedPropertyKeys != _DEFAULT_blankedPropertyKeys
-                else ""
-            ),
-        ]
-
-        return "DeltaTableSpec(" + (", ".join(p for p in parts if p)) + ")"
-
-    # identity manipulation
-    def copy(self) -> "DeltaTableSpec":
-        """Return an independent object that compares equal to this one."""
-        globals = {
-            k: v for k, v in vars(pyspark.sql.types).items() if not k.startswith("_")
-        }
-        globals.update(dict(DeltaTableSpec=DeltaTableSpec))
-        return eval(repr(self), globals)
 
     def get_dh(self) -> DeltaHandle:
         full = self.fully_substituted()

--- a/src/spetlr/deltaspec/DeltaTableSpecBase.py
+++ b/src/spetlr/deltaspec/DeltaTableSpecBase.py
@@ -1,4 +1,5 @@
 import copy
+import dataclasses
 import json
 from dataclasses import asdict, dataclass, field
 from typing import Dict, List, Optional, Union
@@ -8,7 +9,13 @@ from pyspark.sql.types import StructField, StructType
 from spetlr import Configurator
 from spetlr.deltaspec.exceptions import InvalidSpecificationError, TableSpecNotReadable
 from spetlr.deltaspec.helpers import ensureStr, standard_databricks_location
-from spetlr.schema_manager import SchemaManager
+from spetlr.schema_manager.spark_schema import (
+    remove_empty_comments,
+    remove_nullability,
+    schema_to_spark_sql,
+    simplify_column_defaults,
+)
+from spetlr.sqlrepr.sql_types import repr_sql_types
 
 _DEFAULT = object()
 
@@ -65,14 +72,6 @@ class DeltaTableSpecBase:
 
         self.location = standard_databricks_location(self.location)
 
-        # Experiments have shown that the statement
-        # ALTER TABLE she_test.tbl ALTER COLUMN a DROP NOT NULL
-        # does not actually take effect on a table.
-        # So we cannot work with not-nullable columns
-        # in the future, if we want to generate these types
-        # of alter statement, simply remove the following line.
-        self.schema = self.remove_nullability(self.schema)
-
         # the functionality enabled by 'delta.columnMapping.mode' = 'name',
         # is needed for column manipulation and seems to go along with another
         # property "delta.columnMapping.maxColumnId": "5" which increases when
@@ -83,6 +82,31 @@ class DeltaTableSpecBase:
         for key in self.blankedPropertyKeys:
             if key in self.tblproperties:
                 del self.tblproperties[key]
+
+    def __repr__(self):
+        """Return a correct and minimal string,
+         that can be evaluated as python code to return a DeltaTableSpec instance
+        that will compare equal to the current instance."""
+        parts = [
+            (f"name={repr(self.name)}"),
+            f"schema={repr_sql_types(self.schema)}",
+            (f"options={repr(self.options)}" if self.options else ""),
+            (
+                f"partitioned_by={repr(self.partitioned_by)}"
+                if self.partitioned_by
+                else ""
+            ),
+            (f"tblproperties={repr(self.tblproperties)}" if self.tblproperties else ""),
+            (f"comment={repr(self.comment)}" if self.comment else ""),
+            (f"location={repr(self.location)}" if self.location else ""),
+            (
+                f"blankedPropertyKeys={repr(self.blankedPropertyKeys)}"
+                if self.blankedPropertyKeys != _DEFAULT_blankedPropertyKeys
+                else ""
+            ),
+        ]
+
+        return f"{self.__class__.__name__}(" + (", ".join(p for p in parts if p)) + ")"
 
     def set_good_defaults(self):
         """
@@ -134,8 +158,64 @@ class DeltaTableSpecBase:
             raise TableSpecNotReadable("Name or location required to access data.")
         return data_name
 
+    def simplify(self) -> "DeltaTableSpecBase":
+        return dataclasses.replace(self, schema=self.simplified_schema())
+
+    def simplified_schema(self) -> StructType:
+        schema = self.schema
+        # Experiments have shown that the statement
+        # ALTER TABLE she_test.tbl ALTER COLUMN a DROP NOT NULL
+        # does not actually take effect on a table.
+        # So we cannot work with not-nullable columns
+        # in the future, if we want to generate these types
+        # of alter statement, simply remove the following line.
+        schema = remove_nullability(schema)
+
+        # when working with ALTER TABLE statements, there
+        # is no statement to ALTER COLUMN xxx DROP COMMENT
+        # therefore we need to consider empty column comments
+        # as no comments
+        schema = remove_empty_comments(schema)
+
+        # For columns that have a default value,
+        # the metadata seems to contain three values
+        # CURRENT_DEFAULT:
+        #   seems to contain the exact value and spelling as used in
+        #   the DEFAULT claus of the table creation
+        #   example: 'CURRENT_tIMEsTAMP()'
+        # EXISTS_DEFAULT:
+        #   seems to contain the value of the expression if it were
+        #   used right now. example "TIMESTAMP '2023-10-10 14:55:11.315'"
+        # default:
+        #   maybe a standardize form of the manually given default.
+        #   example 'current_timestamp()'
+        #
+        # I have no simple way of extracting the values of
+        # EXISTS_DEFAULT or 'default' for comparison. Therefore,
+        # I will standardize the schema to only keed the value of
+        # CURRENT_DEFAULT and compare those exactly.
+        schema = simplify_column_defaults(schema)
+
+        # as a final precaution, check that the metadata does not contain
+        # anything that we do not support
+        supported_keys = [
+            "comment",
+            "CURRENT_DEFAULT",
+        ]
+        for f in schema.fields:
+            for m_key in f.metadata.keys():
+                if m_key not in supported_keys:
+                    print(
+                        f"WARNING: Column {f.name} "
+                        f"has unknown metadata key {m_key}."
+                        "Expect the make_storage_match method "
+                        "to be insufficient."
+                    )
+
+        return schema
+
     @classmethod
-    def remove_nullability(self, schema: StructType) -> StructType:
+    def remove_nullability_and_commets(cls, schema: StructType) -> StructType:
         """Return a schema where the nullability of all fields is reset to default"""
         fields = []
         for f in schema.fields:
@@ -149,10 +229,14 @@ class DeltaTableSpecBase:
             )
         return StructType(fields)
 
-    # identity manipulation
-    def copy(self) -> "DeltaTableSpecBase":
-        """Return an independent object that compares equal to this one."""
-        return copy.deepcopy(self)
+    @classmethod
+    def as_spec(cls, other):
+        if other is None:
+            return None
+
+        from spetlr.deltaspec import DeltaTableSpec
+
+        return DeltaTableSpec(**dataclasses.asdict(other))
 
     def fully_substituted(self, name=_DEFAULT) -> "DeltaTableSpecBase":
         """Return a new DeltaTableSpec
@@ -175,7 +259,7 @@ class DeltaTableSpecBase:
          that creates the table described by the current DeltaTableSpec instance.
         This method is guaranteed to be the inverse of the `.from_sql(sql)` constructor.
         """
-        schema_str = SchemaManager().struct_to_sql(self.schema, formatted=True)
+        schema_str = schema_to_spark_sql(self.schema, formatted=True)
         self.data_name()  # raise if we cannot point to data
 
         sql = (

--- a/tests/cluster/delta/deltaspec/tables.py
+++ b/tests/cluster/delta/deltaspec/tables.py
@@ -6,7 +6,7 @@ base = DeltaTableSpec.from_sql(
     """
     CREATE TABLE myDeltaTableSpecTestDb{ID}.tbl
     (
-        c double,
+        c double DEFAULT 3.14,
         d string NOT NULL COMMENT "Whatsupp",
         onlyb int,
         a int,

--- a/tests/cluster/schema_manager/test_schema_manager.py
+++ b/tests/cluster/schema_manager/test_schema_manager.py
@@ -6,7 +6,7 @@ from spetlrtools.testing import DataframeTestCase
 from spetlr.configurator import Configurator
 from spetlr.delta import DeltaHandle
 from spetlr.schema_manager import SchemaManager
-from spetlr.schema_manager.spark_schema import get_schema
+from spetlr.schema_manager.spark_schema import get_schema, schema_to_spark_sql
 
 from . import extras
 from .SparkExecutor import SparkSqlExecutor
@@ -98,7 +98,7 @@ class TestSchemaManager(DataframeTestCase):
             ]
         )
 
-        transformed_str = SchemaManager()._schema_to_spark_sql(schema=schema)
+        transformed_str = schema_to_spark_sql(schema=schema)
         expected_str = "Column1 int, Column2 string, Column3 float"
 
         self.maxDiff = None

--- a/tests/local/delta/test_DeltaTableSpec.py
+++ b/tests/local/delta/test_DeltaTableSpec.py
@@ -2,9 +2,11 @@ import dataclasses
 import unittest
 from textwrap import dedent
 
+import pyspark
 from pyspark.sql import types as t
 
 from spetlr import Configurator
+from spetlr.configurator._cli.bformat import bformat
 from spetlr.deltaspec import DeltaTableSpecDifference, TableSpectNotEnforcable
 from spetlr.deltaspec.DeltaTableSpec import DeltaTableSpec
 from tests.cluster.delta.deltaspec import tables
@@ -28,8 +30,8 @@ class TestDeltaTableSpec(unittest.TestCase):
                 """\
                 CREATE TABLE myDeltaTableSpecTestDb{ID}.tbl
                 (
-                  c double,
-                  d string COMMENT "Whatsupp",
+                  c double DEFAULT 3.14,
+                  d string NOT NULL COMMENT "Whatsupp",
                   onlyb int,
                   a int,
                   b int
@@ -101,6 +103,7 @@ class TestDeltaTableSpec(unittest.TestCase):
                 "ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN a COMMENT"
                 ' "gains not null"',
                 'ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN d COMMENT ""',
+                "ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN c DROP DEFAULT",
                 "ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN a FIRST",
                 "ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN b AFTER a",
                 "ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN onlyt AFTER d",
@@ -134,6 +137,8 @@ class TestDeltaTableSpec(unittest.TestCase):
                 "ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN d COMMENT "
                 '"Whatsupp"',
                 'ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN a COMMENT ""',
+                "ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN c "
+                "SET DEFAULT 3.14",
                 "ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN c FIRST",
                 "ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN d AFTER c",
                 "ALTER TABLE mydeltatablespectestdb.tbl ALTER COLUMN onlyb AFTER d",
@@ -180,7 +185,7 @@ class TestDeltaTableSpec(unittest.TestCase):
         )
         Configurator().set_prod()
         d = tbl2.compare_to(tbl1.fully_substituted())
-        self.assertFalse(d.is_different(), d)
+        self.assertFalse(d.is_different(), bformat(repr(d)))
 
     def test_05_namechagne(self):
         statements = tables.newname.compare_to(tables.oldname).alter_statements(
@@ -315,3 +320,14 @@ class TestDeltaTableSpec(unittest.TestCase):
         # ignore the tblproperties and it matches
         diff = diff.ignore("tblproperties")
         self.assertTrue(diff.complete_match(), diff)
+
+    def test_10_repr(self):
+        base = tables.base
+        globals = {
+            k: v for k, v in vars(pyspark.sql.types).items() if not k.startswith("_")
+        }
+        globals.update(dict(DeltaTableSpec=DeltaTableSpec))
+
+        copy_of_base = eval(repr(base), globals)
+
+        self.assertEqual(base, copy_of_base)

--- a/tests/local/delta/test_DeltaTableSpec_recursions.py
+++ b/tests/local/delta/test_DeltaTableSpec_recursions.py
@@ -1,0 +1,32 @@
+import unittest
+from textwrap import dedent
+
+from spetlr import Configurator
+from spetlr.deltaspec.DeltaTableSpec import DeltaTableSpec
+
+
+class TestDeltaTableSpecRecursions(unittest.TestCase):
+    """This class collects test cases for scenarios that
+    have been known to cause problems"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        c = Configurator()
+        c.clear_all_configurations()
+        c.set_prod()
+
+    # not working yet.
+    @unittest.skip
+    def test_01_create_statements(self):
+        _ = DeltaTableSpec.from_sql(
+            dedent(
+                """
+            CREATE OR REPLACE TABLE test.mytbl
+            (
+                id BIGINT GENERATED ALWAYS AS IDENTITY,
+                payload string
+            )
+            USING DELTA;
+        """
+            )
+        )

--- a/tests/local/schema_manager/test_schema_manager.py
+++ b/tests/local/schema_manager/test_schema_manager.py
@@ -4,6 +4,7 @@ import pyspark.sql.types as T
 
 from spetlr.configurator import Configurator
 from spetlr.schema_manager import SchemaManager
+from spetlr.schema_manager.spark_schema import schema_to_spark_sql
 
 from . import extras
 from .extras import initSchemaManager
@@ -69,7 +70,7 @@ class TestSchemaManager(unittest.TestCase):
             ]
         )
         self.assertEqual(
-            "Column1 int, Column2 string, Column3 float", self.sc.struct_to_sql(schema)
+            "Column1 int, Column2 string, Column3 float", schema_to_spark_sql(schema)
         )
         self.assertEqual(
             "Column1 int,\n  Column2 string,\n  Column3 float",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Feature

## Description

The feature of setting column defaults in is now full supported in the DeltaTableSpec. Defaults are parsed from sql and are set and altered in the `make_storage_match` methods. The defaults are also compared in the `.complete_match()`. Also, if the metadata contains any other keys that we did not implement alteration code for, at least spetlr will throw a warning.

### Overview
see description

### What is the current behavior?
DEFAULT is not supported for columns


### Does this PR introduce a breaking change?
no

