### PR TITLE
expose the replacements argument

### DIFF
--- a/src/spetlr/azure_log_analytics/azure_log_analytics_handle.py
+++ b/src/spetlr/azure_log_analytics/azure_log_analytics_handle.py
@@ -100,7 +100,9 @@ class AzureLogAnalyticsHandle(TableHandle):
             "x-ms-date": date_rfc1123_format,
         }
 
-    def api_post(self, df: DataFrame) -> None:
+    def api_post(self, df: DataFrame, mergeSchema: bool = None) -> None:
+        # silently ignore irrelevant mergeSchema
+
         resource = "/api/logs"
 
         uri = self._create_uri(resource=resource)

--- a/src/spetlr/cosmos/cosmos_handle.py
+++ b/src/spetlr/cosmos/cosmos_handle.py
@@ -41,7 +41,12 @@ class CosmosHandle(TableHandle):
     def recreate(self):
         self._cosmos_db.recreate_container_by_name(self._name)
 
-    def append(self, df: DataFrame) -> None:
+    def append(
+        self,
+        df: DataFrame,
+        mergeSchema: bool = None,
+    ) -> None:
+        # ignore mergeSchema silently. Schema evolution works implicitly in cosmos
         self._cosmos_db.write_table_by_name(df, self._name, self._rows_per_partition)
 
     def truncate(self) -> None:
@@ -59,7 +64,9 @@ class CosmosHandle(TableHandle):
         else:
             raise ValueError(f"unsupported flag value of mode: {mode}")
 
-    def overwrite(self, df: DataFrame) -> None:
+    def overwrite(
+        self, df: DataFrame, mergeSchema: bool = None, overwriteSchema: bool = None
+    ) -> None:
         raise NotImplementedError("Method not supported in Cosmos")
 
     def upsert(self, df: DataFrame, join_cols: List[str]) -> Union[DataFrame, None]:

--- a/src/spetlr/sql/SqlExecutor.py
+++ b/src/spetlr/sql/SqlExecutor.py
@@ -181,7 +181,7 @@ class SqlExecutor:
         self,
         file_pattern: str,
         exclude_pattern: str = None,
-        replacements: Optional[dict[str, str]] = None,
+        replacements: Optional[Dict[str, str]] = None,
     ):
         """
         NB: This sql parser can be challenged in parsing sql statements

--- a/src/spetlr/sql/SqlExecutor.py
+++ b/src/spetlr/sql/SqlExecutor.py
@@ -177,7 +177,12 @@ class SqlExecutor:
         if not found and not self.ignore_empty_folder:
             raise ValueError(f"No matching .sql files found in '{self.base_module}'")
 
-    def execute_sql_file(self, file_pattern: str, exclude_pattern: str = None):
+    def execute_sql_file(
+        self,
+        file_pattern: str,
+        exclude_pattern: str = None,
+        replacements: Optional[dict[str, str]] = None,
+    ):
         """
         NB: This sql parser can be challenged in parsing sql statements
         which do not use semicolon as a query separator only.
@@ -187,7 +192,9 @@ class SqlExecutor:
 
         statement = None
 
-        for statement in self.get_statements(file_pattern, exclude_pattern):
+        for statement in self.get_statements(
+            file_pattern, exclude_pattern, replacements
+        ):
             executor.sql(statement)
 
         if statement is None:

--- a/src/spetlr/sql/sql_handle.py
+++ b/src/spetlr/sql/sql_handle.py
@@ -52,12 +52,22 @@ class SqlHandle(TableHandle):
             df_source=df, table_name=self._name, append=append
         )
 
-    def overwrite(self, df: DataFrame) -> None:
+    def overwrite(
+        self, df: DataFrame, mergeSchema: bool = None, overwriteSchema: bool = None
+    ) -> None:
+        if mergeSchema is not None or overwriteSchema is not None:
+            raise ValueError("Schema evolution not supported in sql server")
         return self._sql_server.write_table_by_name(
             df_source=df, table_name=self._name, append=False
         )
 
-    def append(self, df: DataFrame) -> None:
+    def append(
+        self,
+        df: DataFrame,
+        mergeSchema: bool = None,
+    ) -> None:
+        if mergeSchema is not None:
+            raise ValueError("Schema evolution not supported in sql server")
         return self._sql_server.write_table_by_name(
             df_source=df, table_name=self._name, append=True
         )

--- a/src/spetlr/tables/TableHandle.py
+++ b/src/spetlr/tables/TableHandle.py
@@ -7,10 +7,12 @@ class TableHandle:
     def read(self) -> DataFrame:
         raise NotImplementedError()
 
-    def overwrite(self, df: DataFrame) -> None:
+    def overwrite(
+        self, df: DataFrame, mergeSchema: bool = None, overwriteSchema: bool = None
+    ) -> None:
         raise NotImplementedError()
 
-    def append(self, df: DataFrame) -> None:
+    def append(self, df: DataFrame, mergeSchema: bool = None) -> None:
         raise NotImplementedError()
 
     def truncate(self) -> None:

--- a/tests/cluster/delta/test_sparkexecutor.py
+++ b/tests/cluster/delta/test_sparkexecutor.py
@@ -3,7 +3,8 @@ import unittest
 from spetlr import Configurator
 from spetlr.delta import DbHandle, DeltaHandle
 from spetlr.spark import Spark
-from tests.cluster.delta import extras
+from spetlr.sql import SqlExecutor
+from tests.cluster.delta import extras, views
 from tests.cluster.delta.SparkExecutor import SparkSqlExecutor
 
 
@@ -26,7 +27,7 @@ class DeliverySparkExecutorTests(unittest.TestCase):
         DbHandle.from_tc("SparkTestDb").drop_cascade()
         DeltaHandle.from_tc("SparkTestTable1").drop()
 
-    def test_can_execute(self):
+    def test_01_can_execute(self):
         SparkSqlExecutor().execute_sql_file("*", exclude_pattern="debug")
 
         DeltaHandle.from_tc("SparkTestTable1").read()
@@ -40,3 +41,9 @@ class DeliverySparkExecutorTests(unittest.TestCase):
         SparkSqlExecutor().execute_sql_file("*")
 
         DeltaHandle.from_tc("SparkTestTable2").read()
+
+    def test_02_can_use_replacments(self):
+        e = SqlExecutor(base_module=views)
+        e.execute_sql_file("*", replacements={"my_view_name": "customview"})
+
+        _ = Spark.get().table("customview")  # excute without error

--- a/tests/cluster/delta/views/views.sql
+++ b/tests/cluster/delta/views/views.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW {my_view_name}
+AS
+SELECT * from {SparkTestTable1};
+

--- a/tests/cluster/transformations/test_union_transformer.py
+++ b/tests/cluster/transformations/test_union_transformer.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pyspark.sql import DataFrame
+from spetlrtools.testing import TestHandle
 
 from spetlr.etl import Orchestrator
 from spetlr.etl.extractors import SimpleExtractor
@@ -10,36 +10,13 @@ from spetlr.transformers import UnionTransformer
 
 
 class MergeDfIntoTargetTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        pass
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        pass
-
     def test_01_union(self):
         schema = "i integer, s string"
 
-        class Reader:
-            df: DataFrame
+        th1 = TestHandle(provides=Spark.get().createDataFrame([(1, "a")], schema))
+        th2 = TestHandle(provides=Spark.get().createDataFrame([(1, "a")], schema))
 
-            def read(self):
-                return self.df
-
-        th1 = Reader()
-        th1.df = Spark.get().createDataFrame([(1, "a")], schema)
-
-        th2 = Reader()
-        th2.df = Spark.get().createDataFrame([(1, "a")], schema)
-
-        class Writer:
-            df: DataFrame
-
-            def overwrite(self, df: DataFrame):
-                self.df = df
-
-        th3 = Writer()
+        th3 = TestHandle()
 
         o = Orchestrator()
         o.extract_from(SimpleExtractor(th1, "th1"))
@@ -48,4 +25,4 @@ class MergeDfIntoTargetTest(unittest.TestCase):
         o.load_into(SimpleLoader(th3))
         o.execute()
 
-        self.assertEqual(th1.df.schema, th3.df.schema)
+        self.assertEqual(th1.provides.schema, th3.overwritten.schema)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Feature

## Description

the replacements argument allows to reuse sql code multiple times with slightly changed replacements values. It is an oversight that it was not exposed on this method, since it *was* exposed on the `get_statements` method.
