### PR TITLE
Fix the way that comments are parsed so as to not lose trailing quota…

### DIFF
--- a/src/spetlr/schema_manager/spark_schema.py
+++ b/src/spetlr/schema_manager/spark_schema.py
@@ -1,4 +1,5 @@
 import re
+from ast import literal_eval
 from typing import Optional
 
 from more_itertools import peekable
@@ -134,7 +135,7 @@ def _get_comment(iter) -> Optional[str]:
     next(iter)
 
     comment = next(iter).value
-    return comment.strip("'\"")
+    return literal_eval(comment)
 
 
 def _ignore_generated(iter):

--- a/tests/local/schema_manager/test_schema_manager.py
+++ b/tests/local/schema_manager/test_schema_manager.py
@@ -4,9 +4,9 @@ import pyspark.sql.types as T
 
 from spetlr.configurator import Configurator
 from spetlr.schema_manager import SchemaManager
-
-from . import extras
-from .extras import initSchemaManager
+from spetlr.schema_manager.spark_schema import get_schema
+from tests.local.schema_manager import extras
+from tests.local.schema_manager.extras import initSchemaManager
 
 
 class TestSchemaManager(unittest.TestCase):
@@ -75,3 +75,11 @@ class TestSchemaManager(unittest.TestCase):
             "Column1 int,\n  Column2 string,\n  Column3 float",
             self.sc.struct_to_sql(schema, formatted=True),
         )
+
+    def test_05_parse_comments(self):
+        d_field = get_schema(
+            """
+            d string COMMENT 'Whatsupp with "you"',
+        """
+        ).fields[0]
+        self.assertEqual(d_field.metadata, {"comment": 'Whatsupp with "you"'})


### PR DESCRIPTION
…tion marks

## What type of PR is this? (check all applicable)

- Bug Fix

## Description
Before this bug, this schema had the trailing quotation mark stripped from the comment.
```sql
d string COMMENT 'Whatsupp with "you"'
```
