### PR TITLE
Pinned sqlparse>=0.4.4 for Databricks ML Runtime 14.3 compatibility.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ package_dir =
 packages = find:
 install_requires =
     pyyaml
-    sqlparse==0.4.2
+    sqlparse==0.4.4
     Deprecated
     pyodbc
     importlib-metadata

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ package_dir =
 packages = find:
 install_requires =
     pyyaml
-    sqlparse==0.4.4
+    sqlparse>=0.4.4
     Deprecated
     pyodbc
     importlib-metadata

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ package_dir =
 packages = find:
 install_requires =
     pyyaml
-    sqlparse
+    sqlparse==0.4.2
     Deprecated
     pyodbc
     importlib-metadata


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Bug Fix

## Description
This micro-PR fixes an error where the latest PYPI version of `sqlparse` was causing errors with the Databricks ML Runtime 14.3, which uses a pinned `sqlparse==0.4.2`, whereas the version retrieved using `pip install sqlparse` is `sqlparse==0.4.4`.
Oddly, this caused an issue with `Lexer.get_default_instance`, a dependency when using`Configurator` from `spetlr`.
`spetlr` does not specify this version requirement, and hence it is added in this PR.

### Overview
Pins `sqlparse>=0.4.4`.


## More generally: Compatibility with Databricks ML Runtime
´This is likely a common compatibility issue with the Databricks ML Runtime having around 300 python packages, all with pinned versions. If we do not follow their pinned version, `spetlr` may not necessarily be compatible with this runtime. On the other hand, these python package versions change with Databrick ML Runtime versions, and we likely wish to support multiple versions, so we cannot follow their versioning entirely. 
`requirements.txt` for Databricks ML Runtime 14.3: https://docs.databricks.com/en/_extras/documents/requirements-14.3.txt
