### PR TITLE
consume_inputs on CleanColumnNamesTransformer should be True by default

### DIFF
--- a/src/spetlr/transformers/clean_column_names_transformer.py
+++ b/src/spetlr/transformers/clean_column_names_transformer.py
@@ -23,7 +23,7 @@ class CleanColumnNamesTransformer(Transformer):
         exclude_columns: List[str] = None,
         dataset_input_keys: List[str] = None,
         dataset_output_key: str = None,
-        consume_inputs: bool = False,
+        consume_inputs: bool = True,
     ):
         super().__init__(
             dataset_input_keys=dataset_input_keys,


### PR DESCRIPTION
…default

## What type of PR is this? (check all applicable)

- Fix

## Description

consume_inputs on CleanColumnNamesTransformer should be True by default