### PR TITLE
feat: remove cluster resourcegroup

### DIFF
--- a/.github/deploy/destroy.ps1
+++ b/.github/deploy/destroy.ps1
@@ -30,5 +30,17 @@ Write-Host "  Now Destroying Parent Resource Group!" -ForegroundColor Red
 
 az group delete --name $resourceGroupName --yes --no-wait
 
+# Check if the resource group exists
+$clusterrg= "$($resourceGroupName)Cluster"
+$exists = az group exists --name $clusterrg
+
+if ($exists -eq "true") {
+    Write-Host "Resource group $clusterrg exists. Deleting..."
+    az group delete --name $clusterrg --yes --no-wait
+    Write-Host "Deletion command sent for resource group $clusterrg."
+} else {
+    Write-Host "Resource group $clusterrg does not exist."
+}
+
 Write-Host "  Parent Resource Group Deleted" -ForegroundColor Green
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Bug Fix
- Deployment (Azure, CI/CD, PowerShell, ...)


## Description

### Overview
A resourcegroup is created - xxxCluster for some databricks resources when running the PRs. This was prevoiusly automatic removed when the "parent" resourcegroup was deleted. Somehow, this is not automatic. I have created a small feature to handle it.
