### PR TITLE
feat: PowerBi refresh - more precise timeout handling

### DIFF
--- a/src/spetlr/power_bi/PowerBi.py
+++ b/src/spetlr/power_bi/PowerBi.py
@@ -21,8 +21,8 @@ class PowerBi:
         workspace_name: str = None,
         dataset_id: str = None,
         dataset_name: str = None,
-        max_minutes_after_last_refresh: int = 60 * 12,
-        timeout_in_seconds: int = 60 * 15,
+        max_minutes_after_last_refresh: int = 12 * 60,
+        timeout_in_seconds: int = 15 * 60,
         number_of_retries: int = 0,
         local_timezone_name: str = "UTC",
         ignore_errors: bool = False,
@@ -62,6 +62,20 @@ class PowerBi:
             raise ValueError("Specify either 'workspace_id' or 'workspace_name'!")
         if dataset_id is not None and dataset_name is not None:
             raise ValueError("Specify either 'dataset_id' or 'dataset_name'!")
+        if max_minutes_after_last_refresh is None or max_minutes_after_last_refresh < 0:
+            raise ValueError(
+                "The 'max_minutes_after_last_refresh' parameter "
+                "must be greater than or equal zero!"
+            )
+        if timeout_in_seconds is None or timeout_in_seconds <= 0:
+            raise ValueError(
+                "The 'timeout_in_seconds' parameter must be greater than zero!"
+            )
+        if number_of_retries is None or number_of_retries < 0:
+            raise ValueError(
+                "The 'number_of_retries' parameter "
+                "must be greater than or equal zero!"
+            )
 
         self.workspace_id = workspace_id
         self.workspace_name = workspace_name
@@ -74,7 +88,9 @@ class PowerBi:
         self.max_minutes_after_last_refresh = max_minutes_after_last_refresh
         self.timeout_in_seconds = timeout_in_seconds
         self.number_of_retries = number_of_retries
-        self.local_timezone_name = local_timezone_name
+        self.local_timezone_name = (
+            local_timezone_name if local_timezone_name is not None else "UTC"
+        )
         self.ignore_errors = ignore_errors
         self.api_header = None
         self.expire_time = 0
@@ -82,7 +98,7 @@ class PowerBi:
         self.last_status = None
         self.last_exception = None
         self.last_refresh_utc = None
-        self.last_duration = 0
+        self.last_duration_in_seconds = 0
 
     def _raise_error(self, message: str) -> None:
         if self.ignore_errors:
@@ -262,7 +278,7 @@ class PowerBi:
         self.last_status = None
         self.last_exception = None
         self.last_refresh_utc = None
-        self.last_duration = 0
+        self.last_duration_in_seconds = 0
 
         api_url = (
             f"{self.powerbi_url}groups/{self.workspace_id}"
@@ -296,7 +312,7 @@ class PowerBi:
                 ):
                     self.last_refresh_utc = parser.parse(end_time).replace(tzinfo=utc)
                     if start_time is not None and len(start_time) > 0:
-                        self.last_duration = int(
+                        self.last_duration_in_seconds = int(
                             (
                                 parser.parse(end_time) - parser.parse(start_time)
                             ).total_seconds()
@@ -396,7 +412,7 @@ class PowerBi:
             )
         return False
 
-    def _get_seconds_to_wait(self, elapsed: int) -> int:
+    def _get_seconds_to_wait(self, elapsed_seconds: int) -> int:
         """
         Returns the number of seconds to wait before rechecking
             if the refresh has completed. The method makes sure as few requests
@@ -411,10 +427,21 @@ class PowerBi:
         # (small delay) we check through polling if the refresh has finished and
         # how soon (large delay) will the refresh() method complete.
 
-        if self.last_duration > 0:
-            elapsed = abs(self.last_duration - elapsed)
+        remaining_seconds = self.timeout_in_seconds - elapsed_seconds
 
-        return 15 if elapsed < 40 else 60 if elapsed < (3 * 60) else (5 * 60)
+        wait_seconds = elapsed_seconds
+        if self.last_duration_in_seconds > 0:
+            wait_seconds = abs(self.last_duration_in_seconds - elapsed_seconds)
+
+        wait_seconds = (
+            15 if wait_seconds < 40 else 60 if wait_seconds < (3 * 60) else (5 * 60)
+        )
+
+        return (
+            remaining_seconds
+            if (0 < remaining_seconds < wait_seconds)
+            else wait_seconds
+        )
 
     def check(self) -> bool:
         """
@@ -454,11 +481,11 @@ class PowerBi:
             return False
 
         while True:
-            elapsed = int(time.time() - start_time)
-            if elapsed > self.timeout_in_seconds:
+            elapsed_seconds = int(time.time() - start_time)
+            if elapsed_seconds >= self.timeout_in_seconds:
                 print("Timeout!")
                 break
-            wait_seconds = self._get_seconds_to_wait(elapsed)
+            wait_seconds = self._get_seconds_to_wait(elapsed_seconds)
             print(f"Waiting {wait_seconds} seconds...")
             time.sleep(wait_seconds)
 

--- a/src/spetlr/power_bi/PowerBi.py
+++ b/src/spetlr/power_bi/PowerBi.py
@@ -126,7 +126,7 @@ class PowerBi:
                 return True
             print("Renewing access token...")
 
-        # Prepare URLs (note: we fetch only the latest refresh record, i.e. top=1)
+        # Prepare URLs
         authority_url = f"https://login.microsoftonline.com/{self.client.tenant_id}/"
         scope = ["https://analysis.windows.net/powerbi/api/.default"]
         self.powerbi_url = "https://api.powerbi.com/v1.0/myorg/"
@@ -152,7 +152,6 @@ class PowerBi:
         else:
             self.expire_time = time.time() + default_expires_in - extra_seconds
 
-        # Get latest Power BI Dataset refresh record
         self.api_header = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {access_token}",
@@ -280,6 +279,7 @@ class PowerBi:
         self.last_refresh_utc = None
         self.last_duration_in_seconds = 0
 
+        # Note: we fetch only the latest refresh record, i.e. top=1
         api_url = (
             f"{self.powerbi_url}groups/{self.workspace_id}"
             f"/datasets/{self.dataset_id}/refreshes?$top=1"

--- a/tests/local/power_bi/test_power_bi.py
+++ b/tests/local/power_bi/test_power_bi.py
@@ -263,7 +263,7 @@ class TestPowerBi(unittest.TestCase):
         sut = PowerBi(PowerBiClient(), timeout_in_seconds=90)
         sut.last_duration_in_seconds = 15 * 60
         elapsed = 5
-        expected_result = 90
+        expected_result = 90 - elapsed
 
         # Act
         result = sut._get_seconds_to_wait(elapsed)

--- a/tests/local/power_bi/test_power_bi.py
+++ b/tests/local/power_bi/test_power_bi.py
@@ -128,7 +128,7 @@ class TestPowerBi(unittest.TestCase):
         self.assertEqual(sut.last_status, "Completed")
         self.assertIsNone(sut.last_exception)
         self.assertEqual(str(sut.last_refresh_utc), "2024-02-26 10:05:00+00:00")
-        self.assertEqual(sut.last_duration, 300)
+        self.assertEqual(sut.last_duration_in_seconds, 5 * 60)
 
     @patch("requests.get")
     def test_get_last_refresh_failure(self, mock_get):
@@ -235,7 +235,7 @@ class TestPowerBi(unittest.TestCase):
     def test_get_seconds_to_wait_first(self):
         # Arrange
         sut = PowerBi(PowerBiClient())
-        sut.last_duration = 0
+        sut.last_duration_in_seconds = 0
         elapsed = 5
         expected_result = 15
 
@@ -248,9 +248,22 @@ class TestPowerBi(unittest.TestCase):
     def test_get_seconds_to_wait_next(self):
         # Arrange
         sut = PowerBi(PowerBiClient())
-        sut.last_duration = 60 * 15
+        sut.last_duration_in_seconds = 15 * 60
         elapsed = 5
-        expected_result = 60 * 5
+        expected_result = 5 * 60
+
+        # Act
+        result = sut._get_seconds_to_wait(elapsed)
+
+        # Assert
+        self.assertEqual(result, expected_result)
+
+    def test_get_seconds_to_wait_exceeding_timeout(self):
+        # Arrange
+        sut = PowerBi(PowerBiClient(), timeout_in_seconds=90)
+        sut.last_duration_in_seconds = 15 * 60
+        elapsed = 5
+        expected_result = 90
 
         # Act
         result = sut._get_seconds_to_wait(elapsed)


### PR DESCRIPTION
## What type of PR is this?
- Feature

### Overview
The "timeout_in_seconds" parameter in the PowerBi constructor should be treated literally,
and the refresh() method should finish exactly at timeout.

### What is the current behavior?
The refresh() method waits max. 5 minutes between two PowerBI API requests,
which means the refresh() method could take up to 5 minutes longer after the timeout.

### What is the new behavior?
The refresh() method must finish exactly at timeout or earlier.

### Does this PR introduce a breaking change?
No