### PR TITLE
PowerBi.refresh() - use last completed refresh time

### DIFF
--- a/src/spetlr/power_bi/PowerBi.py
+++ b/src/spetlr/power_bi/PowerBi.py
@@ -277,7 +277,6 @@ class PowerBi:
         self.last_status = None
         self.last_exception = None
         self.last_refresh_utc = None
-        self.last_duration_in_seconds = 0
 
         # Note: we fetch only the latest refresh record, i.e. top=1
         api_url = (

--- a/tests/local/power_bi/test_power_bi.py
+++ b/tests/local/power_bi/test_power_bi.py
@@ -139,6 +139,8 @@ class TestPowerBi(unittest.TestCase):
 
         sut = PowerBi(PowerBiClient(), workspace_id="test", dataset_id="test")
         sut.powerbi_url = "test"
+        sut.last_status = "test"
+        sut.last_duration_in_seconds = 5
         sut._connect = lambda: True
 
         # Act
@@ -150,6 +152,8 @@ class TestPowerBi(unittest.TestCase):
             "The specified dataset or workspace cannot be found",
             str(context.exception),
         )
+        self.assertIsNone(sut.last_status)  # must be cleared!
+        self.assertEqual(sut.last_duration_in_seconds, 5)  # must be kept unchanged!
 
     def test_verify_last_refresh_success(self):
         # Arrange


### PR DESCRIPTION
## What type of PR is this?
- Bug Fix

## Description
When executing PowerBi.refresh(), use the previous completed refresh time regardless of a pending new refresh. This allows the refresh() method finish sooner.

### What is the current behavior?
The previous completed refresh time was overwritten when checking the pending refresh, so every sleep was 5 minutes.

### What is the new behavior?
The previous completed refresh time is now taken into consideration when executing sleep(), so the last sleep can be shorter (e.g. 60 seconds or 15 seconds) to match the previous refresh execution time.

### Does this PR introduce a breaking change?
No