### PR TITLE
Remove managed resource group when destroying

### DIFF
--- a/.github/deploy/destroy.ps1
+++ b/.github/deploy/destroy.ps1
@@ -1,11 +1,11 @@
 # delete the entire deployment to save running costs
 param (
-  [Parameter(Mandatory=$false)]
+  [Parameter(Mandatory = $false)]
   [ValidateNotNullOrEmpty()]
   [string]
-  $environmentName="",
+  $environmentName = "",
 
-  [Parameter(Mandatory=$false)]
+  [Parameter(Mandatory = $false)]
   [string]
   $uniqueRunId
 )
@@ -29,6 +29,7 @@ Write-Host "Initialize deployment" -ForegroundColor Green
 Write-Host "  Now Destroying Parent Resource Group!" -ForegroundColor Red
 
 az group delete --name $resourceGroupName --yes --no-wait
+az group delete --name "$($resourceGroupName)Cluster" --yes --no-wait
 
 Write-Host "  Parent Resource Group Deleted" -ForegroundColor Green
 

--- a/.github/deploy/destroy.ps1
+++ b/.github/deploy/destroy.ps1
@@ -29,7 +29,18 @@ Write-Host "Initialize deployment" -ForegroundColor Green
 Write-Host "  Now Destroying Parent Resource Group!" -ForegroundColor Red
 
 az group delete --name $resourceGroupName --yes --no-wait
-az group delete --name "$($resourceGroupName)Cluster" --yes --no-wait
-
 Write-Host "  Parent Resource Group Deleted" -ForegroundColor Green
+
+Start-Sleep -Seconds 30
+
+# ATM, deleting the resource group above does not completely delete the managed resource group.
+# Thus, we delete it here. If this is fixed by Azure, we can remove this step.
+if (az group exists --name "$($resourceGroupName)Cluster" = true ) {
+  Write-Host "  Managed resource group exists, Deleting it..." -ForegroundColor Green
+  az group delete --name "$($resourceGroupName)Cluster" --yes --no-wait
+}
+else {
+  Write-Host "  Managed resource group does not exist, skipping..."
+}
+
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Bug Fix in Deployment (Destroying)


## Description

### Overview
With the introduction of automatic UC enablement in Databricks deployment, deleting a resource group containg a Databricks account does not completely remove the managed resource group that is deployed by Azure Databricks.
To mitigiate this issue with the Azure deployment, we have added an extra step for the Resource group destruction step in this PR to not only delete the main spetlr resource group, but also the managed Azure Databricks resource group. 

### What is the current behavior?
With every spetlr deployment, the Azure Datbricks managed resource group created and not completely deleted. Therefore, redundant resource groups are piled up over time.

### What is the new behavior?
Every spetlr deployment should remove all the created resources at the end.

### Does this PR introduce a breaking change?
No.

## Related Issues (Link to the open issue)
None

## Additional information
None
