### PR TITLE
feat: use get() instead of table_property() - DEPRECATED

### DIFF
--- a/src/spetlr/configurator/configurator.py
+++ b/src/spetlr/configurator/configurator.py
@@ -367,6 +367,9 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         key = json_hash(kwargs)
         return self.register(key, kwargs)
 
+    @deprecated(
+        reason="Use .get(table_id,property_name) instead.",
+    )
     def table_property(
         self, table_id: str, property_name: str, default_value: str = None
     ):
@@ -395,7 +398,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         :param table_id: Table id in the .json or .yaml files.
         :return: str: table name
         """
-        return self.table_property(table_id, "name")
+        return self.get(table_id, "name")
 
     @deprecated(
         reason='Use .get(table_id,"path") instead.',

--- a/src/spetlr/cosmos/cosmos.py
+++ b/src/spetlr/cosmos/cosmos.py
@@ -173,7 +173,7 @@ class CosmosDb(CosmosBaseServer):
     def from_tc(self, table_id: str) -> CosmosHandle:
         tc = Configurator()
         name = tc.table_name(table_id)
-        rows_per_partition = tc.table_property(table_id, "rows_per_partition", "")
+        rows_per_partition = tc.get(table_id, "rows_per_partition", "")
         rows_per_partition = int(rows_per_partition) if rows_per_partition else None
 
         try:

--- a/src/spetlr/delta/db_handle.py
+++ b/src/spetlr/delta/db_handle.py
@@ -28,8 +28,8 @@ class DbHandle:
         tc = Configurator()
         return cls(
             name=tc.table_name(id),
-            location=tc.table_property(id, "path", ""),
-            data_format=tc.table_property(id, "format", "db"),
+            location=tc.get(id, "path", ""),
+            data_format=tc.get(id, "format", "db"),
         )
 
     def _validate(self):

--- a/src/spetlr/delta/delta_handle.py
+++ b/src/spetlr/delta/delta_handle.py
@@ -80,13 +80,13 @@ class DeltaHandle(TableHandle):
     def from_tc(cls, id: str) -> "DeltaHandle":
         tc = Configurator()
         return cls(
-            name=tc.table_property(id, "name", ""),
-            location=tc.table_property(id, "path", ""),
+            name=tc.get(id, "name", ""),
+            location=tc.get(id, "path", ""),
             schema=SchemaManager().get_schema(id, None),
-            data_format=tc.table_property(id, "format", "delta"),
-            ignore_changes=tc.table_property(id, "ignore_changes", "True"),
-            stream_start=tc.table_property(id, "stream_start", ""),
-            max_bytes_per_trigger=tc.table_property(id, "max_bytes_per_trigger", ""),
+            data_format=tc.get(id, "format", "delta"),
+            ignore_changes=tc.get(id, "ignore_changes", "True"),
+            stream_start=tc.get(id, "stream_start", ""),
+            max_bytes_per_trigger=tc.get(id, "max_bytes_per_trigger", ""),
         )
 
     def _validate(self):

--- a/src/spetlr/eh/EventHubCapture.py
+++ b/src/spetlr/eh/EventHubCapture.py
@@ -38,10 +38,10 @@ class EventHubCapture:
     def from_tc(cls, id: str):
         tc = Configurator()
         return cls(
-            name=tc.table_property(id, "name"),
-            path=tc.table_property(id, "path"),
-            format=tc.table_property(id, "format"),
-            partitioning=tc.table_property(id, "partitioning"),
+            name=tc.get(id, "name"),
+            path=tc.get(id, "path"),
+            format=tc.get(id, "format"),
+            partitioning=tc.get(id, "partitioning"),
         )
 
     def __init__(

--- a/src/spetlr/eh/EventHubCaptureExtractor.py
+++ b/src/spetlr/eh/EventHubCaptureExtractor.py
@@ -27,10 +27,10 @@ class EventHubCaptureExtractor:
     @classmethod
     def from_tc(cls, tbl_id: str):
         tc = Configurator()
-        assert tc.table_property(tbl_id, "format") == "avro"
+        assert tc.get(tbl_id, "format") == "avro"
         return cls(
-            path=tc.table_property(tbl_id, "path"),
-            partitioning=tc.table_property(tbl_id, "partitioning"),
+            path=tc.get(tbl_id, "path"),
+            partitioning=tc.get(tbl_id, "partitioning"),
         )
 
     def __init__(self, path: str, partitioning: str):

--- a/src/spetlr/utils/DeleteMismatchedSchemas.py
+++ b/src/spetlr/utils/DeleteMismatchedSchemas.py
@@ -16,7 +16,7 @@ def get_table_ids_to_check():
     c = Configurator()
     table_ids_to_check = []
     for key in c._raw_resource_details.keys():
-        if c.table_property(key, "delete_on_delta_schema_mismatch", False):
+        if c.get(key, "delete_on_delta_schema_mismatch", False):
             table_ids_to_check.append(key)
     return table_ids_to_check
 

--- a/tests/local/configurator/test_configurator.py
+++ b/tests/local/configurator/test_configurator.py
@@ -81,7 +81,7 @@ class TestConfigurator(unittest.TestCase):
         tc.add_resource_path(tables4)
         details = tc.get_all_details()
         self.assertTrue("MyFreeTable_eggs", details)
-        self.assertEqual(tc.table_property("MyFreeTable", "bacon"), "")
+        self.assertEqual(tc.get("MyFreeTable", "bacon"), "")
 
     def test_07_bare_strings_and_structures(self):
         tc = Configurator()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Refactor
- Bug Fix


## Description

### Overview
The spetlr configurator has a generic `.get()` method which should be used instead of `.table_property()`. References to "table" is legacy, as this configurator does not only configurate tables. Furthermore, I hae experienced issues with the default valiue of the table property method.

### Does this PR introduce a breaking change?
It deprecates the `.table_property()`
