### PR TITLE
feat: update mismatched schemas

### DIFF
--- a/src/spetlr/utils/UpdateMismatchedSchemas.py
+++ b/src/spetlr/utils/UpdateMismatchedSchemas.py
@@ -1,0 +1,49 @@
+from typing import List
+
+from spetlr.configurator import Configurator
+from spetlr.deltaspec import DeltaTableSpec
+
+
+def get_table_ids_to_check():
+    print("Remember to initialize the configurator first!")
+    c = Configurator()
+    table_ids_to_check = []
+    for key in c._raw_resource_details.keys():
+        if c.table_property(key, "update_on_delta_schema_mismatch", False):
+            table_ids_to_check.append(key)
+    return table_ids_to_check
+
+
+def UpdateMismatchedSchemas(
+    table_ids_to_check: List[str] = None,
+):
+    """For the following tables, if the production schema does not match
+    the configured schema, update delta table and truncate.
+
+    It is the responsibility of the developer to only add tables here where the
+    code has the property that it can rebuild dropped tables.
+
+    Tables can be flagged by using ´update_on_delta_schema_mismatch´
+    as Configurator property.
+
+    """
+
+    if table_ids_to_check is None:
+        table_ids_to_check = get_table_ids_to_check()
+
+    for tbl_id in table_ids_to_check:
+        tbl_spec = DeltaTableSpec.from_tc(tbl_id)
+        if tbl_spec.compare_to_name().is_different():
+            print(f"Updating table with id {tbl_id}")
+            tbl_spec.make_storage_match(
+                allow_columns_add=True,
+                allow_columns_drop=True,
+                allow_columns_type_change=True,
+                allow_columns_reorder=True,
+                allow_name_change=True,
+                allow_location_change=True,
+                allow_table_create=True,
+                errors_as_warnings=True,
+            )
+        else:
+            print(f"No change for table with id {tbl_id}")

--- a/tests/cluster/utils/test_update_schema_mismatch.py
+++ b/tests/cluster/utils/test_update_schema_mismatch.py
@@ -1,0 +1,92 @@
+import uuid as _uuid
+
+import pyspark.sql.types as T
+from spetlrtools.testing import DataframeTestCase
+
+from spetlr.configurator import Configurator
+from spetlr.delta import DbHandle, DeltaHandle
+from spetlr.sql import SqlExecutor
+from spetlr.utils import DeleteMismatchedSchemas
+from spetlr.utils.UpdateMismatchedSchemas import UpdateMismatchedSchemas
+from tests.cluster.utils import extras
+
+
+class TestUpdateSchemaMismatch(DataframeTestCase):
+    """
+    Test class for UpdateMismatchedSchemas.
+
+    This class contains tests for the `UpdateMismatchedSchemas` utility class.
+    It verifies the behavior of the utility when dealing with Delta tables
+    that have schema mismatches.
+
+    The class defines the initial and changed schema for testing purposes.
+    It also sets up the necessary configuration and resources for the tests.
+
+    NB: This test is special, since it expects production tables.
+        Do not use .set_prod() in tests.
+
+    """
+
+    initial_schema_delta = T.StructType(
+        [
+            T.StructField("a", T.IntegerType(), True),
+        ]
+    )
+
+    changed_schema_delta = T.StructType(
+        [
+            T.StructField("a", T.IntegerType(), True),
+            T.StructField("b", T.IntegerType(), True),
+        ]
+    )
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        Configurator().register("mismatchuuid", str(_uuid.uuid4().hex))
+        Configurator().add_resource_path(extras)
+
+        # This extra configuration is necessary
+        # since SPETLR tests runs parallel on multiple cluster
+        # but in same Databricks workspace
+        # The production tables will interfere with each other without an unique id
+
+        # This is a special case.
+        # Dont use set_prod in testcases
+        Configurator().set_prod()
+
+        cls.executor = SqlExecutor(base_module=extras)
+
+    def test_01_no_change_delta(self):
+        """Test scenario with no schema change in Delta table."""
+        dbhandle = DbHandle.from_tc("SparkTestDbMismatch")
+        dbhandle.drop_cascade()
+
+        # Setup production table
+
+        self.executor.execute_sql_file("initial_schema")
+
+        dh = DeltaHandle.from_tc("MismatchSparkTestTable")
+
+        self.assertEqual(dh.read().schema, self.initial_schema_delta)
+
+        UpdateMismatchedSchemas()
+
+        self.assertEqual(dh.read().schema, self.initial_schema_delta)
+
+    def test_02_change_delta(self):
+        """Test scenario with schema change in Delta table."""
+        # Ensure that the database is dropped
+        dbhandle = DbHandle.from_tc("SparkTestDbMismatch")
+        dbhandle.drop_cascade()
+
+        # Setup production table
+        self.executor.execute_sql_file("initial_schema")
+
+        dh = DeltaHandle.from_tc("MismatchSparkTestTable")
+
+        self.assertEqual(dh.read().schema, self.initial_schema_delta)
+
+        UpdateMismatchedSchemas()
+        self.executor.execute_sql_file("changed_schema")
+
+        self.assertEqual(dh.read().schema, self.changed_schema_delta)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Feature


## Description

### Overview
This is an new version of the `DeleteMismatchedSchemas`. THis utilizes the deltaspec. It checks the table ids with `update_on_delta_mismatch` and uses the deltaspec make_storage_match and truncate.
