### PR TITLE
feat: PowerBI - get and show the refresh history list

### DIFF
--- a/docs/power_bi/README.md
+++ b/docs/power_bi/README.md
@@ -118,8 +118,8 @@ The number of minutes can be specified in the optional
 "max_minutes_after_last_refresh" parameter (default is 12 hours).
 
 You can also specify the optional "local_timezone_name" parameter to show
-the last refresh time of the PowerBI dataset in a local timezone.
-It is only used for printing timestamps. Default timezone is UTC.
+the last refresh time of the PowerBI dataset in a local time zone.
+It is only used for printing timestamps. The default time zone is UTC.
 
 All parameters can only be specified in the constructor. 
 
@@ -162,7 +162,10 @@ if the refresh succeeded.
 
 If you want to refresh only selected tables in the dataset, you can
 specify the optional "table_names" parameter with a list of table names.
-If the list is not empty, only the selected tables will be refreshed. 
+If the list is not empty, only the selected tables will be refreshed.
+(Note: It is not possible to list available tables programmatically
+using the PowerBI API, like you can do with workspaces and datasets.
+You have to check the table names visually in PowerBI.)
 
 All parameters can only be specified in the constructor. 
 
@@ -198,13 +201,13 @@ parameter (default is 15 minutes).
 If the refresh fails or a time-out occurs, the method casts an exception.
 
 The wait time between calls to the PowerBI API is synchronized with the
-execution time of the previous dataset refresh, making sure as few requests
-to the PowerBI API would be made as possible, while ensuring the method
-would finish as soon as possible.
+average execution time of previous dataset refreshes via API (only calls
+refreshing all tables), making sure as few requests to the PowerBI API would
+be made as possible, while ensuring the method finishes as soon as possible.
 
 If you want to refresh only selected tables in the dataset, you can
 specify the optional "table_names" parameter with a list of table names.
-If the list is not empty, only the selected tables will be refreshed
+If the list is not empty, only selected tables will be refreshed
 (and the previous refresh time will be ignored).
 
 Additionally, you can set the optional "number_of_retries" parameter to
@@ -213,9 +216,9 @@ Default is 0 (no retries). E.g. 1 means two attempts in total.
 It is used only when the "timeout_in_seconds" parameter allows it,
 so you need to set the "timeout_in_seconds" parameter high enough.
 
-You can also specify the optional "local_timezone_name" parameter to show
-the last refresh time of the PowerBI dataset in a local timezone.
-It is only used for printing timestamps. Default timezone is UTC.
+You can also specify the optional "local_timezone_name" parameter to
+show the last refresh time of the PowerBI dataset in a local time zone.
+It is only used for printing timestamps. The default time zone is UTC. 
 
 All parameters can only be specified in the constructor. 
 
@@ -247,6 +250,55 @@ Waiting 60 seconds...
 Waiting 15 seconds...
 Refresh completed successfully at 2024-02-02 09:02 (local time).
 True
+```
+
+## Step 7: Show and get the refresh history of a given dataset
+
+The show_history() and get_history() methods can be used to show and get
+the refresh history of a given dataset. The show_history() method displays
+a Pandas data frame with the refresh history, and the get_history() method
+returns the actual data frame converted to a Spark data frame. 
+
+According to MSDN, "there are always between 20–60 available refresh history
+entries for each dataset, depending on the number of refreshes in the last 3 days.
+The most recent 60 are kept if they are all less than 3 days old. Entries
+more than 3 days old are deleted when there are more than 20 entries."
+
+You can also specify the optional "local_timezone_name" parameter to convert
+refresh times in the data frame to a local timezone. Depending on the parameter,
+the names of the time columns in the data frame will have the suffix
+"Utc" or "Local".
+
+All above parameters can only be specified in the constructor. 
+
+```python
+# example show and get refresh history
+from spetlr.power_bi.PowerBi import PowerBi 
+
+client = MyPowerBiClient()
+PowerBi(client,
+        workspace_name="Finance",
+        dataset_name="Invoicing",
+        local_timezone_name="Europe/Copenhagen").show_history()
+
+PowerBi(client,
+        workspace_name="Finance",
+        dataset_name="Invoicing",
+        local_timezone_name="Europe/Copenhagen").show_history()
+
+# alternatively:
+df = PowerBi(client,
+        workspace_id="614850c2-3a5c-4d2d-bcaa-d3f20f32a2e0",
+        dataset_id="b1f0a07e-e348-402c-a2b2-11f3e31181ce",
+        local_timezone_name="Europe/Copenhagen").get_history()
+
+df = PowerBi(client,
+        workspace_id="614850c2-3a5c-4d2d-bcaa-d3f20f32a2e0",
+        dataset_id="b1f0a07e-e348-402c-a2b2-11f3e31181ce",
+        local_timezone_name="Europe/Copenhagen").get_history()
+
+df.display()
+
 ```
 
 # Testing

--- a/src/spetlr/power_bi/PowerBi.py
+++ b/src/spetlr/power_bi/PowerBi.py
@@ -278,7 +278,8 @@ class PowerBi:
         Return the PowerBI dataset refresh history.
 
         :param bool newest_only : Limit the result to only the latest history row.
-        :return: data frame with the refresh history if succeeded or None if failed (when ignore_errors==True)
+        :return: data frame with the refresh history if succeeded or None if failed
+        (when ignore_errors==True)
         :rtype: Pandas data frame
         :raises SpetlrException: if failed and ignore_errors==False
         """
@@ -317,7 +318,8 @@ class PowerBi:
 
             self.schema = (
                 "Id long, RefreshType string, Status string, Seconds long, "
-                f"StartTime{self.time_column_suffix} timestamp, EndTime{self.time_column_suffix} timestamp, "
+                f"StartTime{self.time_column_suffix} timestamp, "
+                f"EndTime{self.time_column_suffix} timestamp, "
                 "Error string, RequestId string, RefreshAttempts string"
             )
 
@@ -394,7 +396,8 @@ class PowerBi:
         if not df.empty:
             self.last_status = df.Status.iloc[0]
             self.last_exception = df.Error.iloc[0]
-            # claculate the average duration of all previous API refresh calls without any tables specified
+            # claculate the average duration of all previous API refresh calls
+            # without any tables specified
             mean = df.loc[
                 (df["RefreshType"] == "ViaApi") & (df["Status"] == "Completed"),
                 df.Seconds.name,
@@ -608,7 +611,8 @@ class PowerBi:
         """
         Displays the refresh history of a PowerBI dataset.
 
-        :return: data frame with the refresh history if succeeded or None if failed (when ignore_errors==True)
+        :return: data frame with the refresh history if succeeded or None if failed
+        (when ignore_errors==True)
         :rtype: Pandas data frame
         :raises SpetlrException: if failed and ignore_errors==False
         """
@@ -624,7 +628,8 @@ class PowerBi:
         """
         Returns the refresh history of a PowerBI dataset in a Spark data frame.
 
-        :return: data frame with the refresh history if succeeded or None if failed (when ignore_errors==True)
+        :return: data frame with the refresh history if succeeded or None if failed
+        (when ignore_errors==True)
         :rtype: Spark data frame
         :raises SpetlrException: if failed and ignore_errors==False
         """

--- a/tests/local/power_bi/test_power_bi.py
+++ b/tests/local/power_bi/test_power_bi.py
@@ -321,8 +321,8 @@ class TestPowerBi(unittest.TestCase):
                     "refreshType": "OnDemand",
                     "status": "Completed",
                     "startTime": "2024-02-26T10:00:00Z",
-                    "endTime": "2024-02-26T10:05:00Z",  # winter time: 1 hour difference from UTC
-                    "serviceExceptionJson": None,
+                    "endTime": "2024-02-26T10:05:00Z",  # winter time: 1 hour
+                    "serviceExceptionJson": None,  # difference from UTC
                     "requestId": "74d25c0b-0473-4dd9-96ff-3ca737b072a7",
                     "refreshAttempts": None,
                 },
@@ -330,8 +330,8 @@ class TestPowerBi(unittest.TestCase):
                     "id": "2",
                     "refreshType": "ViaEnhancedApi",
                     "status": "Completed",
-                    "startTime": "2024-03-31T00:00:00Z",  # summer time: change from 1 hour to 2 hours difference !
-                    "endTime": "2024-03-31T02:00:00Z",
+                    "startTime": "2024-03-31T00:00:00Z",  # summer time: change from 1
+                    "endTime": "2024-03-31T02:00:00Z",  # hour to 2 hours difference
                     "serviceExceptionJson": None,
                     "requestId": "aec28227-f7af-4c2d-a4e6-fcb01cd570ec",
                     "refreshAttempts": None,
@@ -356,7 +356,8 @@ class TestPowerBi(unittest.TestCase):
                 "Seconds": [
                     300,
                     7200,
-                ],  # despite the daylight saving change it correctly shows 7200 seconds !
+                ],  # despite the daylight saving change it
+                # correctly shows 7200 seconds !
                 "StartTimeLocal": [
                     datetime(2024, 2, 26, 11, 0),
                     datetime(2024, 3, 31, 1, 0),

--- a/tests/local/power_bi/test_power_bi.py
+++ b/tests/local/power_bi/test_power_bi.py
@@ -2,6 +2,8 @@ import unittest
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
+import pandas as pd
+from pandas.testing import assert_frame_equal
 from pytz import utc
 
 from spetlr.exceptions import SpetlrException
@@ -28,7 +30,7 @@ class TestPowerBi(unittest.TestCase):
 
         # Assert
         self.assertTrue(result)
-        self.assertEqual(sut.workspace_id, "614850c2-3a5c-4d2d-bcaa-d3f20f32a2e0")
+        self.assertEqual("614850c2-3a5c-4d2d-bcaa-d3f20f32a2e0", sut.workspace_id)
 
     @patch("requests.get")
     def test_get_workspace_failure(self, mock_get):
@@ -72,7 +74,7 @@ class TestPowerBi(unittest.TestCase):
 
         # Assert
         self.assertTrue(result)
-        self.assertEqual(sut.dataset_id, "b1f0a07e-e348-402c-a2b2-11f3e31181ce")
+        self.assertEqual("b1f0a07e-e348-402c-a2b2-11f3e31181ce", sut.dataset_id)
 
     @patch("requests.get")
     def test_get_dataset_failure(self, mock_get):
@@ -106,7 +108,7 @@ class TestPowerBi(unittest.TestCase):
                 {
                     "requestId": "1",
                     "id": "1",
-                    "refreshType": "Manual",
+                    "refreshType": "ViaApi",
                     "startTime": "2024-02-26T10:00:00Z",
                     "endTime": "2024-02-26T10:05:00Z",
                     "status": "Completed",
@@ -125,10 +127,10 @@ class TestPowerBi(unittest.TestCase):
 
         # Assert
         self.assertTrue(result)
-        self.assertEqual(sut.last_status, "Completed")
+        self.assertEqual("Completed", sut.last_status)
         self.assertIsNone(sut.last_exception)
-        self.assertEqual(str(sut.last_refresh_utc), "2024-02-26 10:05:00+00:00")
-        self.assertEqual(sut.last_duration_in_seconds, 5 * 60)
+        self.assertEqual("2024-02-26 10:05:00+00:00", str(sut.last_refresh_utc))
+        self.assertEqual(5 * 60, sut.last_duration_in_seconds)
 
     @patch("requests.get")
     def test_get_last_refresh_failure(self, mock_get):
@@ -153,7 +155,7 @@ class TestPowerBi(unittest.TestCase):
             str(context.exception),
         )
         self.assertIsNone(sut.last_status)  # must be cleared!
-        self.assertEqual(sut.last_duration_in_seconds, 5)  # must be kept unchanged!
+        self.assertEqual(5, sut.last_duration_in_seconds)  # must be kept unchanged!
 
     def test_verify_last_refresh_success(self):
         # Arrange
@@ -222,7 +224,7 @@ class TestPowerBi(unittest.TestCase):
         # Assert
         self.assertIsNotNone(result)
         self.assertTrue("objects" in result)
-        self.assertEqual(result["objects"], expected_result)
+        self.assertEqual(expected_result, result["objects"])
 
     @patch("requests.post")
     def test_trigger_new_refresh_success(self, mock_get):
@@ -279,7 +281,7 @@ class TestPowerBi(unittest.TestCase):
         result = sut._get_seconds_to_wait(elapsed)
 
         # Assert
-        self.assertEqual(result, expected_result)
+        self.assertEqual(expected_result, result)
 
     def test_get_seconds_to_wait_next(self):
         # Arrange
@@ -292,7 +294,7 @@ class TestPowerBi(unittest.TestCase):
         result = sut._get_seconds_to_wait(elapsed)
 
         # Assert
-        self.assertEqual(result, expected_result)
+        self.assertEqual(expected_result, result)
 
     def test_get_seconds_to_wait_exceeding_timeout(self):
         # Arrange
@@ -305,4 +307,99 @@ class TestPowerBi(unittest.TestCase):
         result = sut._get_seconds_to_wait(elapsed)
 
         # Assert
-        self.assertEqual(result, expected_result)
+        self.assertEqual(expected_result, result)
+
+    @patch("requests.get")
+    def test_get_refresh_history_success(self, mock_get):
+        # Arrange
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "value": [
+                {
+                    "id": "1",
+                    "refreshType": "OnDemand",
+                    "status": "Completed",
+                    "startTime": "2024-02-26T10:00:00Z",
+                    "endTime": "2024-02-26T10:05:00Z",  # winter time: 1 hour difference from UTC
+                    "serviceExceptionJson": None,
+                    "requestId": "74d25c0b-0473-4dd9-96ff-3ca737b072a7",
+                    "refreshAttempts": None,
+                },
+                {
+                    "id": "2",
+                    "refreshType": "ViaEnhancedApi",
+                    "status": "Completed",
+                    "startTime": "2024-03-31T00:00:00Z",  # summer time: change from 1 hour to 2 hours difference !
+                    "endTime": "2024-03-31T02:00:00Z",
+                    "serviceExceptionJson": None,
+                    "requestId": "aec28227-f7af-4c2d-a4e6-fcb01cd570ec",
+                    "refreshAttempts": None,
+                },
+            ]
+        }
+        mock_get.return_value = mock_response
+
+        sut = PowerBi(
+            PowerBiClient(),
+            workspace_id="test",
+            dataset_id="test",
+            local_timezone_name="Europe/Copenhagen",
+        )
+        sut.powerbi_url = "test"
+        sut._connect = lambda: True
+        expected = pd.DataFrame(
+            {
+                "Id": ["1", "2"],
+                "RefreshType": ["OnDemand", "ViaEnhancedApi"],
+                "Status": ["Completed", "Completed"],
+                "Seconds": [
+                    300,
+                    7200,
+                ],  # despite the daylight saving change it correctly shows 7200 seconds !
+                "StartTimeLocal": [
+                    datetime(2024, 2, 26, 11, 0),
+                    datetime(2024, 3, 31, 1, 0),
+                ],
+                "EndTimeLocal": [
+                    datetime(2024, 2, 26, 11, 5),
+                    datetime(2024, 3, 31, 4, 0),
+                ],
+                "Error": [None, None],
+                "RequestId": [
+                    "74d25c0b-0473-4dd9-96ff-3ca737b072a7",
+                    "aec28227-f7af-4c2d-a4e6-fcb01cd570ec",
+                ],
+                "RefreshAttempts": None,
+            }
+        )
+
+        # Act
+        result = sut._get_refresh_history()
+
+        # Assert
+        self.assertIsNotNone(result)
+        assert_frame_equal(expected, result)
+
+    @patch("requests.get")
+    def test_get_refresh_history_failure(self, mock_get):
+        # Arrange
+        mock_response = Mock()
+        mock_response.status_code = 404  # dataset or workspace not found
+        mock_get.return_value = mock_response
+
+        sut = PowerBi(PowerBiClient(), workspace_id="test", dataset_id="test")
+        sut.powerbi_url = "test"
+        sut.last_status = "test"
+        sut._connect = lambda: True
+
+        # Act
+        with self.assertRaises(SpetlrException) as context:
+            sut._get_refresh_history()
+
+        # Assert
+        self.assertIn(
+            "The specified dataset or workspace cannot be found",
+            str(context.exception),
+        )
+        self.assertIsNone(sut.last_status)  # must be cleared!


### PR DESCRIPTION
What type of PR is this?
- Feature

Overview
The PowerBi refreshing logic has been extended with two new methods to show and get the refresh history list. The list is returned as a Spark data frame. Additionally, the last refresh time is calculated as an average of all previous refresh times via API (only those refreshing the entire dataset), to make the logic execute faster.

What is the current behavior?
There is no such feature.

Does this PR introduce a breaking change?
No, the logic is optional