### PR TITLE
stream from name

### DIFF
--- a/src/spetlr/delta/delta_handle.py
+++ b/src/spetlr/delta/delta_handle.py
@@ -280,7 +280,7 @@ class DeltaHandle(TableHandle):
         if self._location:
             df = reader.load(self._location)
         else:
-            df = reader.table(self._table_name)
+            df = reader.table(self._name)
 
         return df
 


### PR DESCRIPTION
Streaming must read from the full table name, not from the name of the table within its DB