### PR TITLE
Add the "case_sensitive" parameter to the EhJsonToDeltaOrchestrator

### DIFF
--- a/src/spetlr/orchestrators/ehjson2delta/EhJsonToDeltaOrchestrator.py
+++ b/src/spetlr/orchestrators/ehjson2delta/EhJsonToDeltaOrchestrator.py
@@ -11,7 +11,13 @@ from spetlr.orchestrators.ehjson2delta.EhJsonToDeltaTransformer import (
 
 
 class EhJsonToDeltaOrchestrator(Orchestrator):
-    def __init__(self, eh: EventHubCaptureExtractor, dh: DeltaHandle):
+    def __init__(
+        self,
+        eh: EventHubCaptureExtractor,
+        dh: DeltaHandle,
+        *,
+        case_sensitive: bool = True,
+    ):
         super().__init__()
         self.eh = eh
         self.dh = dh
@@ -25,7 +31,9 @@ class EhJsonToDeltaOrchestrator(Orchestrator):
         # step 2,
         #  - use the target schema to select what to copy from capture files
         #  - anything that is not in the source df is used to unpack the body json
-        self.transform_with(EhJsonToDeltaTransformer(target_dh=dh))
+        self.transform_with(
+            EhJsonToDeltaTransformer(target_dh=dh, case_sensitive=case_sensitive)
+        )
 
         # the method filter_with can be used to insert any number of transformers here
 

--- a/tests/cluster/eh/test_eh_json_transformer.py
+++ b/tests/cluster/eh/test_eh_json_transformer.py
@@ -30,7 +30,9 @@ class JsonEhTransformerUnitTests(DataframeTestCase):
                         "id": 1234,
                         "name": "John",
                     }
-                ).encode("utf-8"),  # Body
+                ).encode(
+                    "utf-8"
+                ),  # Body
                 dt_utc(2021, 10, 31, 0, 0, 0),  # pdate
                 dt_utc(2021, 10, 31, 0, 0, 0),  # EnqueuedTimestamp
             ),


### PR DESCRIPTION
## What type of PR is this?
- Feature

### Overview
The EhJsonToDeltaOrchestrator class should have a new optional parameter to disable case-sensitivity
when parsing JSON property names.

### What is the current behavior?
There is no parameter.

### What is the new behavior?
The EhJsonToDeltaOrchestrator class constructor has a new boolean parameter named "case_sensitive".

### Does this PR introduce a breaking change?
No