### PR TITLE
Ensure backward compatiblity for spetlr delta handle read

### DIFF
--- a/src/spetlr/delta/delta_handle.py
+++ b/src/spetlr/delta/delta_handle.py
@@ -123,8 +123,10 @@ class DeltaHandle(TableHandle):
             raise DeltaHandleInvalidFormat("Only format delta is supported.")
 
     def read(self) -> DataFrame:
-        """Read table is always by name."""
-        return Spark.get().table(self._name)
+        """If name is available, always read the table by name."""
+        if not self._location or (self._name and "." in self._name):
+            return Spark.get().table(self._name)
+        return Spark.get().read.format(self._data_format).load(self._location)
 
     def write_or_append(
         self,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- Bug Fix

### Overview
Ensure backward compatibility for spetlr delta handle read()
table "path" is used when reading instead of table "name" if the name was not specified or it does not contain a dot.
Until the recent release, spetlr always used only "path". 

### What is the current behavior?
The previous release introduced a breaking change.

### What is the new behavior?
This release removes the breaking change.

### Does this PR introduce a breaking change?
No