### PR TITLE
Add support for Databricks Connect

### DIFF
--- a/docs/spark/README.md
+++ b/docs/spark/README.md
@@ -1,0 +1,44 @@
+
+# Spark class
+
+The `Spark` class should be utilized to start a Spark session in Spetlr.
+Sessions are created using the standard `pyspark.sql.SparkSession` class.
+However, it is also possible to switch to Databricks Connect for Python,
+and use the `databricks.connect.DatabricksSession` class instead. This can
+be useful to run unit tests and integration tests from your local machine.
+
+The library itself is not part of the Spetlr package, and it needs to be
+installed separately using pip or poetry. It is loaded by Spetlr
+dynamically, if needed, and can be used instead of the SparkSession class.
+Be sure to install the right version of the "databricks-connect" library
+matching the Databricks runtime on your cluster, e.g. 14.3.
+
+To use Databricks Connect with Spetlr, all you need to do is to set
+the following environment variable in your operating system to "True": 
+
+**SPETLR_DATABRICKS_CONNECT**
+
+If the library is available, the Spark class will utilize
+Databricks Connect. The library will connect to the configured cluster
+automatically and spin it up if necessary.
+
+After installing the library using pip or poetry, you can set up
+Databricks Connect using e.g. the following PowerShell commands.
+Just set the correct host URL to your Databricks workspace, and change
+the profile name below to your liking. Databricks will let you choose
+a cluster and remember it. 
+
+``` 
+$my_profile='profile1',
+$host_url='https://xxxxxxxxxx.azuredatabricks.net'
+
+[System.Environment]::SetEnvironmentVariable("SPETLR_DATABRICKS_CONNECT", $true, [System.EnvironmentVariableTarget]::User)
+
+[System.Environment]::SetEnvironmentVariable("DATABRICKS_CONFIG_PROFILE", $my_profile, [System.EnvironmentVariableTarget]::User)
+
+databricks auth login --configure-cluster --profile $my_profile --host $host_url
+
+databricks auth env --profile $my_profile
+``` 
+
+[Additional info on Databricks Connect can be found here...](https://docs.databricks.com/en/dev-tools/databricks-connect/python/index.html)

--- a/src/spetlr/spark.py
+++ b/src/spetlr/spark.py
@@ -8,8 +8,8 @@ Some standard options are pre-set, call configure with value=None to remove them
 # This class uses module level singleton pattern as suggested by method5 of
 # https://stackoverflow.com/questions/6760685/creating-a-singleton-in-python
 
-import os
 import importlib
+import os
 from typing import Optional, Tuple
 
 from pyspark.sql import SparkSession

--- a/src/spetlr/spark.py
+++ b/src/spetlr/spark.py
@@ -89,6 +89,7 @@ class Spark:
                 return spark
             except ImportError:
                 raise ValueError("databricks.connect not installed") from None
+        return None
 
     @classmethod
     def version(cls) -> Tuple:

--- a/src/spetlr/utils/DataframeCreator.py
+++ b/src/spetlr/utils/DataframeCreator.py
@@ -45,7 +45,7 @@ class DataframeCreator:
         for column, item in zip(columns, data_row):
             if isinstance(column, str):
                 # we are dealing with a simple column
-                assert column in schema.names
+                assert column in schema.names, f"column '{column}' is missing!"
                 in_data[column] = item
 
             else:
@@ -59,7 +59,9 @@ class DataframeCreator:
                         column_schema, item, column_schema_selection
                     )
                 else:
-                    assert isinstance(column_schema, ArrayType)
+                    assert isinstance(
+                        column_schema, ArrayType
+                    ), f"column type is {type(column_schema)}!"
                     in_data[column_name] = cls._make_row_array(
                         column_schema, item, column_schema_selection
                     )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- Feature

### Overview
Add support for Databricks Connect.

### What is the current behavior?
No support

### What is the new behavior?
Support for Databricks Connect is added and can be enabled using an environment variable.
See the documentation in: docs/spark.README.md

### Does this PR introduce a breaking change?
No