### PR TITLE
Recursion error in configurator

### DIFF
--- a/src/spetlr/configurator/configurator.py
+++ b/src/spetlr/configurator/configurator.py
@@ -205,7 +205,9 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
                 # will raise ValueError if there are too few parts,
                 # keys without _ are handled below
 
-                value = self._get_item_property(id_part, property_part, _forbidden_keys)
+                value = self._get_item_property(
+                    id_part, property_part, _forbidden_keys.copy()
+                )
                 # raises ValueError if it does not exist
 
                 replacements[key] = value

--- a/tests/local/configurator/test_configurator_recursion.py
+++ b/tests/local/configurator/test_configurator_recursion.py
@@ -1,0 +1,18 @@
+import unittest
+
+from spetlr import Configurator
+
+
+class TestConfigurator(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        Configurator().clear_all_configurations()
+
+    def test_01_recursion(self):
+        tc = Configurator()
+        tc.register("BASE", "foobar")
+        tc.register("FIRST", "really {BASE}")
+        print(tc.get("FIRST"))
+
+        tc.register("SECOND", " {BASE} really {FIRST}")
+        print(tc.get("SECOND"))


### PR DESCRIPTION
See the test in this PR.
The configurator erroneously identified a circular dependency because it reused the stack for each branch of the dependency resolution. This is fixed now.