### PR TITLE
feat: treat unity catalog location as none

### DIFF
--- a/src/spetlr/deltaspec/DeltaTableSpec.py
+++ b/src/spetlr/deltaspec/DeltaTableSpec.py
@@ -99,8 +99,11 @@ class DeltaTableSpec(DeltaTableSpecBase):
         spark = Spark.get()
         try:
             details = spark.sql(f"DESCRIBE DETAIL {in_name}").collect()[0].asDict()
+
         except AnalysisException as e:
             raise NoTableAtTarget(str(e))
+
+
         if details["format"] != "delta":
             raise InvalidSpecificationError("The table is not of delta format.")
 

--- a/src/spetlr/deltaspec/DeltaTableSpec.py
+++ b/src/spetlr/deltaspec/DeltaTableSpec.py
@@ -103,7 +103,6 @@ class DeltaTableSpec(DeltaTableSpecBase):
         except AnalysisException as e:
             raise NoTableAtTarget(str(e))
 
-
         if details["format"] != "delta":
             raise InvalidSpecificationError("The table is not of delta format.")
 

--- a/src/spetlr/deltaspec/DeltaTableSpecBase.py
+++ b/src/spetlr/deltaspec/DeltaTableSpecBase.py
@@ -55,6 +55,12 @@ class DeltaTableSpecBase:
             # we should treat this like an unspecified location
             self.location = None
 
+        # If the table is a managed UC table
+        # the location is set to None
+        # Since there is no external location per se
+        if "__unitystorage/catalogs" in self.location:
+            self.location = None
+
         self.comment = ensureStr(self.comment)
 
         if self.name and "{" not in self.name:

--- a/src/spetlr/deltaspec/DeltaTableSpecBase.py
+++ b/src/spetlr/deltaspec/DeltaTableSpecBase.py
@@ -58,8 +58,9 @@ class DeltaTableSpecBase:
         # If the table is a managed UC table
         # the location is set to None
         # Since there is no external location per se
-        if "__unitystorage/catalogs" in self.location:
-            self.location = None
+        if self.location is not None:
+            if "__unitystorage/catalogs" in self.location:
+                self.location = None
 
         self.comment = ensureStr(self.comment)
 

--- a/tests/local/deltaspec/test_table_spec_from_sql.py
+++ b/tests/local/deltaspec/test_table_spec_from_sql.py
@@ -1,9 +1,10 @@
 import unittest
 from unittest.mock import patch
+
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
 from spetlr.deltaspec.DeltaTableSpec import DeltaTableSpec
 from spetlr.deltaspec.exceptions import InvalidSpecificationError
-
-from pyspark.sql.types import StructType, StructField, IntegerType, StringType
 
 
 class TestDeltaTableSpecFromSQL(unittest.TestCase):
@@ -22,14 +23,19 @@ class TestDeltaTableSpecFromSQL(unittest.TestCase):
             "options": {"mergeSchema": "true"},
             "partitioned_by": ["id"],
             "cluster_by": [],
-            "tblproperties": {"delta.minReaderVersion": "2", "delta.minWriterVersion": "5"},
+            "tblproperties": {
+                "delta.minReaderVersion": "2",
+                "delta.minWriterVersion": "5",
+            },
         }
 
         # Use a real StructType schema instead of a mock
-        expected_schema = StructType([
-            StructField("id", IntegerType(), True),
-            StructField("name", StringType(), True)
-        ])
+        expected_schema = StructType(
+            [
+                StructField("id", IntegerType(), True),
+                StructField("name", StringType(), True),
+            ]
+        )
         mock_get_schema.return_value = expected_schema
 
         # Input SQL
@@ -51,8 +57,13 @@ class TestDeltaTableSpecFromSQL(unittest.TestCase):
 
         # Assertions
         self.assertEqual(spec.name, "test_db.test_table")
-        self.assertEqual(spec.schema, expected_schema)  # Now correctly compares StructType
-        self.assertEqual(spec.location, "abfss://catalog@storage.dfs.core.windows.net/tables/test_table")
+        self.assertEqual(
+            spec.schema, expected_schema
+        )  # Now correctly compares StructType
+        self.assertEqual(
+            spec.location,
+            "abfss://catalog@storage.dfs.core.windows.net/tables/test_table",
+        )
         self.assertEqual(spec.comment, "Test Delta Table")
         self.assertEqual(spec.options, {"mergeSchema": "true"})
         self.assertEqual(spec.partitioned_by, ["id"])
@@ -61,7 +72,7 @@ class TestDeltaTableSpecFromSQL(unittest.TestCase):
         expected_tblproperties = {
             "delta.minReaderVersion": "2",
             "delta.minWriterVersion": "5",
-            "delta.columnMapping.mode": "name"
+            "delta.columnMapping.mode": "name",
         }
         self.assertEqual(spec.tblproperties, expected_tblproperties)
 
@@ -79,7 +90,7 @@ class TestDeltaTableSpecFromSQL(unittest.TestCase):
         with self.assertRaises(InvalidSpecificationError):
             DeltaTableSpec.from_sql(sql)
 
-    from pyspark.sql.types import StructType, StructField, IntegerType
+    from pyspark.sql.types import IntegerType, StructField, StructType
 
     def test_from_sql_missing_fields(self):
         """Test DeltaTableSpec.from_sql with missing optional fields."""
@@ -91,8 +102,11 @@ class TestDeltaTableSpecFromSQL(unittest.TestCase):
         USING DELTA
         """
 
-        with patch("spetlr.configurator.sql.parse_sql.parse_single_sql_statement") as mock_parse_sql, \
-            patch("spetlr.schema_manager.spark_schema.get_schema") as mock_get_schema:
+        with patch(
+            "spetlr.configurator.sql.parse_sql.parse_single_sql_statement"
+        ) as mock_parse_sql, patch(
+            "spetlr.schema_manager.spark_schema.get_schema"
+        ) as mock_get_schema:
             mock_parse_sql.return_value = {
                 "name": "test_db.test_table",
                 "format": "delta",
@@ -113,7 +127,9 @@ class TestDeltaTableSpecFromSQL(unittest.TestCase):
 
             # Assertions for missing values
             self.assertEqual(spec.name, "test_db.test_table")
-            self.assertEqual(spec.schema, expected_schema)  # Now correctly compares StructType
+            self.assertEqual(
+                spec.schema, expected_schema
+            )  # Now correctly compares StructType
             self.assertIsNone(spec.location)  # Should be None when not provided
             self.assertIsNone(spec.comment)  # Should be None when not provided
             self.assertEqual(spec.options, {})
@@ -124,7 +140,7 @@ class TestDeltaTableSpecFromSQL(unittest.TestCase):
             expected_tblproperties = {
                 "delta.minReaderVersion": "2",
                 "delta.minWriterVersion": "5",
-                "delta.columnMapping.mode": "name"
+                "delta.columnMapping.mode": "name",
             }
             self.assertEqual(spec.tblproperties, expected_tblproperties)
 

--- a/tests/local/deltaspec/test_table_spec_from_sql.py
+++ b/tests/local/deltaspec/test_table_spec_from_sql.py
@@ -1,0 +1,133 @@
+import unittest
+from unittest.mock import patch
+from spetlr.deltaspec.DeltaTableSpec import DeltaTableSpec
+from spetlr.deltaspec.exceptions import InvalidSpecificationError
+
+from pyspark.sql.types import StructType, StructField, IntegerType, StringType
+
+
+class TestDeltaTableSpecFromSQL(unittest.TestCase):
+    @patch("spetlr.configurator.sql.parse_sql.parse_single_sql_statement")
+    @patch("spetlr.schema_manager.spark_schema.get_schema")
+    def test_from_sql_valid(self, mock_get_schema, mock_parse_sql):
+        """Test DeltaTableSpec.from_sql with a valid CREATE TABLE statement."""
+
+        # Mock SQL parsing result
+        mock_parse_sql.return_value = {
+            "name": "test_db.test_table",
+            "format": "delta",
+            "schema": {"sql": "id INT, name STRING"},
+            "path": "abfss://catalog@storage.dfs.core.windows.net/tables/test_table",
+            "comment": "Test Delta Table",
+            "options": {"mergeSchema": "true"},
+            "partitioned_by": ["id"],
+            "cluster_by": [],
+            "tblproperties": {"delta.minReaderVersion": "2", "delta.minWriterVersion": "5"},
+        }
+
+        # Use a real StructType schema instead of a mock
+        expected_schema = StructType([
+            StructField("id", IntegerType(), True),
+            StructField("name", StringType(), True)
+        ])
+        mock_get_schema.return_value = expected_schema
+
+        # Input SQL
+        sql = """
+        CREATE TABLE test_db.test_table (
+            id INT,
+            name STRING
+        )
+        USING DELTA
+        LOCATION 'abfss://catalog@storage.dfs.core.windows.net/tables/test_table'
+        COMMENT 'Test Delta Table'
+        OPTIONS ('mergeSchema'='true')
+        PARTITIONED BY (id)
+        TBLPROPERTIES ('delta.minReaderVersion'='2', 'delta.minWriterVersion'='5')
+        """
+
+        # Run method
+        spec = DeltaTableSpec.from_sql(sql)
+
+        # Assertions
+        self.assertEqual(spec.name, "test_db.test_table")
+        self.assertEqual(spec.schema, expected_schema)  # Now correctly compares StructType
+        self.assertEqual(spec.location, "abfss://catalog@storage.dfs.core.windows.net/tables/test_table")
+        self.assertEqual(spec.comment, "Test Delta Table")
+        self.assertEqual(spec.options, {"mergeSchema": "true"})
+        self.assertEqual(spec.partitioned_by, ["id"])
+        self.assertEqual(spec.cluster_by, [])
+
+        expected_tblproperties = {
+            "delta.minReaderVersion": "2",
+            "delta.minWriterVersion": "5",
+            "delta.columnMapping.mode": "name"
+        }
+        self.assertEqual(spec.tblproperties, expected_tblproperties)
+
+    def test_from_sql_invalid_format(self):
+        """Test DeltaTableSpec.from_sql with non-delta format (should raise InvalidSpecificationError)."""
+
+        sql = """
+        CREATE TABLE test_db.test_table (
+            id INT,
+            name STRING
+        )
+        USING PARQUET
+        """
+
+        with self.assertRaises(InvalidSpecificationError):
+            DeltaTableSpec.from_sql(sql)
+
+    from pyspark.sql.types import StructType, StructField, IntegerType
+
+    def test_from_sql_missing_fields(self):
+        """Test DeltaTableSpec.from_sql with missing optional fields."""
+
+        sql = """
+        CREATE TABLE test_db.test_table (
+            id INT
+        )
+        USING DELTA
+        """
+
+        with patch("spetlr.configurator.sql.parse_sql.parse_single_sql_statement") as mock_parse_sql, \
+            patch("spetlr.schema_manager.spark_schema.get_schema") as mock_get_schema:
+            mock_parse_sql.return_value = {
+                "name": "test_db.test_table",
+                "format": "delta",
+                "schema": {"sql": "id INT"},
+                "location": None,  # Explicitly setting location to None
+                "comment": None,  # Explicitly setting comment to None
+                "options": {},
+                "partitioned_by": [],
+                "cluster_by": [],
+                "tblproperties": {},  # No tblproperties provided, so defaults should be applied
+            }
+
+            # Use a real StructType instead of a string
+            expected_schema = StructType([StructField("id", IntegerType(), True)])
+            mock_get_schema.return_value = expected_schema
+
+            spec = DeltaTableSpec.from_sql(sql)
+
+            # Assertions for missing values
+            self.assertEqual(spec.name, "test_db.test_table")
+            self.assertEqual(spec.schema, expected_schema)  # Now correctly compares StructType
+            self.assertIsNone(spec.location)  # Should be None when not provided
+            self.assertIsNone(spec.comment)  # Should be None when not provided
+            self.assertEqual(spec.options, {})
+            self.assertEqual(spec.partitioned_by, [])
+            self.assertEqual(spec.cluster_by, [])
+
+            # Assert that default tblproperties are set correctly
+            expected_tblproperties = {
+                "delta.minReaderVersion": "2",
+                "delta.minWriterVersion": "5",
+                "delta.columnMapping.mode": "name"
+            }
+            self.assertEqual(spec.tblproperties, expected_tblproperties)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/local/deltaspec/test_table_spec_helper_defs.py
+++ b/tests/local/deltaspec/test_table_spec_helper_defs.py
@@ -1,0 +1,162 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from pyspark.sql import Row, DataFrame
+from pyspark.sql.types import StructType, StructField, IntegerType, StringType
+
+from spetlr.deltaspec import DeltaTableSpecBase
+from spetlr.deltaspec.DeltaTableSpec import DeltaTableSpec
+from spetlr.deltaspec.DeltaTableSpecDifference import DeltaTableSpecDifference
+from spetlr.delta import DeltaHandle
+from spetlr.deltaspec.exceptions import TableSpecNotReadable
+
+
+class TestDeltaTableSpecMethods(unittest.TestCase):
+
+    def setUp(self):
+        """Setup a sample DeltaTableSpec object."""
+        self.schema = StructType([
+            StructField("id", IntegerType(), True),
+            StructField("name", StringType(), True)
+        ])
+
+        self.spec = DeltaTableSpec(
+            name="test_db.test_table",
+            schema=self.schema,
+            location="abfss://storage/tables/test_table",
+            tblproperties={"delta.minReaderVersion": "2", "delta.minWriterVersion": "5"}
+        )
+
+    def test_copy(self):
+        """Test that copy() returns an independent object that compares equal to the original."""
+        spec_copy = self.spec.copy()
+
+        self.assertEqual(self.spec, spec_copy)
+        self.assertIsNot(self.spec, spec_copy)  # Ensure they are different objects in memory
+
+    def test_get_dh(self):
+        """Test that get_dh() returns a valid DeltaHandle with expected values."""
+        dh = self.spec.get_dh()
+
+        self.assertIsInstance(dh, DeltaHandle)
+        self.assertEqual(dh.get_tablename(), self.spec.name)  # Ensuring the name is correct
+        self.assertEqual(dh._location, self.spec.location)  # Ensuring the location matches
+        self.assertEqual(dh._data_format, "delta")  # Ensuring format is always delta
+
+    def test_compare_to(self):
+        """Test that compare_to() returns a DeltaTableSpecDifference object."""
+
+        other_spec = self.spec.copy()
+
+        # Run the method to get the actual result
+        result = self.spec.compare_to(other_spec)
+
+        # Ensure the result is a DeltaTableSpecDifference instance
+        self.assertIsInstance(result, DeltaTableSpecDifference)
+
+        # Ensure base and target are correctly assigned
+        self.assertEqual(result.base.name, other_spec.name)
+        self.assertEqual(result.base.schema, other_spec.schema)
+        self.assertEqual(result.base.tblproperties, other_spec.tblproperties)
+        self.assertEqual(result.base.location, other_spec.location)
+
+        self.assertEqual(result.target.name, self.spec.name)
+        self.assertEqual(result.target.schema, self.spec.schema)
+        self.assertEqual(result.target.tblproperties, self.spec.tblproperties)
+        self.assertEqual(result.target.location, self.spec.location)
+
+    @patch.object(DeltaTableSpec, "compare_to_name")
+    def test_compare_to_location(self, mock_compare_to_name):
+        """Test that compare_to_location() calls compare_to_name correctly."""
+
+        # Mock return value
+        mock_compare_to_name.return_value = "mocked_result"
+
+        # Call the method
+        result = self.spec.compare_to_location()
+
+        # Ensure the method returns the expected result
+        self.assertEqual(result, "mocked_result")
+
+        # Ensure compare_to_name() was called exactly once
+        mock_compare_to_name.assert_called_once()
+
+    @patch.object(DeltaTableSpec, "from_name")
+    def test_compare_to_name(self, mock_from_name):
+        """Test that compare_to_name() correctly compares with the catalog table."""
+
+        # Mock from_name() to return a copied version of self.spec
+        other_spec = self.spec.copy()
+        mock_from_name.return_value = other_spec
+
+        # Convert expected mock return value to DeltaTableSpecBase
+        expected_base = DeltaTableSpecBase(
+            name=other_spec.name,
+            schema=other_spec.schema,
+            options=other_spec.options,
+            partitioned_by=other_spec.partitioned_by,
+            cluster_by=other_spec.cluster_by,
+            tblproperties=other_spec.tblproperties,
+            location=other_spec.location,
+            comment=other_spec.comment,
+            blankedPropertyKeys=['delta.columnMapping.maxColumnId']
+        )
+
+        expected_target = DeltaTableSpecBase(
+            name=self.spec.name,
+            schema=self.spec.schema,
+            options=self.spec.options,
+            partitioned_by=self.spec.partitioned_by,
+            cluster_by=self.spec.cluster_by,
+            tblproperties=self.spec.tblproperties,
+            location=self.spec.location,
+            comment=self.spec.comment,
+            blankedPropertyKeys=['delta.columnMapping.maxColumnId']
+        )
+
+        # Call the method
+        result = self.spec.compare_to_name()
+
+        # Ensure the result is a DeltaTableSpecDifference object
+        self.assertIsInstance(result, DeltaTableSpecDifference)
+
+        # Ensure base and target match expectations
+        self.assertEqual(result.base, expected_base)  # Convert mock return to DeltaTableSpecBase
+        self.assertEqual(result.target, expected_target)
+
+        # Ensure from_name() was called with the correct table name
+        mock_from_name.assert_called_once_with(self.spec.name)
+
+    @patch("spetlr.spark.Spark.get")
+    def test_ensure_df_schema(self, mock_spark_get):
+        """Test that ensure_df_schema() raises TableSpecNotReadable if schema mismatch occurs."""
+        # Create a mock DataFrame with an incompatible schema
+        mismatched_schema = StructType([
+            StructField("id", IntegerType(), True),
+            StructField("email", StringType(), True)  # Different field name
+        ])
+
+        mock_df = MagicMock(spec=DataFrame)
+        mock_df.schema = mismatched_schema
+
+        with self.assertRaises(TableSpecNotReadable):
+            self.spec.ensure_df_schema(mock_df)
+
+    @patch.object(DeltaTableSpec, "compare_to_name")
+    def test_is_readable(self, mock_compare_to_name):
+        """Test that is_readable() returns the correct boolean result."""
+
+        # Case 1: When is_readable() should return True
+        mock_compare_to_name.return_value.is_readable.return_value = True
+        result = self.spec.is_readable()
+        self.assertTrue(result)
+
+        # Case 2: When is_readable() should return False
+        mock_compare_to_name.return_value.is_readable.return_value = False
+        result = self.spec.is_readable()
+        self.assertFalse(result)
+
+        # Ensure compare_to_name() was called twice (once per case)
+        self.assertEqual(mock_compare_to_name.call_count, 2)
+
+
+

--- a/tests/local/deltaspec/test_table_spec_mkstgmatch.py
+++ b/tests/local/deltaspec/test_table_spec_mkstgmatch.py
@@ -1,0 +1,171 @@
+import unittest
+from unittest.mock import call, patch
+
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+from spetlr.deltaspec.DeltaTableSpec import DeltaTableSpec
+from spetlr.deltaspec.DeltaTableSpecDifference import DeltaTableSpecDifference
+from spetlr.spark import Spark
+
+
+class TestDeltaTableSpecMakeStorageMatch(unittest.TestCase):
+    """
+    Test suite for the `make_storage_match` method in DeltaTableSpec.
+
+    This test suite covers the following scenarios:
+
+    1. **test_make_storage_match_no_changes**
+       - Ensures that `make_storage_match()` does nothing if the table already matches the specification.
+
+    2. **test_make_storage_match_add_column**
+       - Verifies that `make_storage_match()` correctly executes an `ALTER TABLE ... ADD COLUMN` statement when needed.
+
+    3. **test_make_storage_match_drop_column**
+       - Checks that `make_storage_match()` executes an `ALTER TABLE ... DROP COLUMN` statement when columns should be removed.
+
+    4. **test_make_storage_match_change_column_type**
+       - Ensures that `make_storage_match()` executes an `ALTER TABLE ... ALTER COLUMN` statement when column types need modification.
+
+    5. **test_make_storage_match_create_table**
+       - Simulates a missing table and verifies that `make_storage_match(allow_table_create=True)` executes a `CREATE TABLE` statement.
+
+    6. **test_make_storage_match_multiple_changes**
+       - Ensures `make_storage_match()` correctly applies multiple changes (adding, dropping, altering columns) in a single run.
+
+    Each test mocks Spark SQL execution to verify that the correct SQL statements are generated and executed.
+    """
+
+    def setUp(self):
+        """Setup a sample DeltaTableSpec object with a basic schema."""
+        self.schema = StructType(
+            [
+                StructField("id", IntegerType(), True),
+                StructField("name", StringType(), True),
+            ]
+        )
+
+        self.spec = DeltaTableSpec(
+            name="test_db.test_table",
+            schema=self.schema,  # Now includes a schema
+            location="abfss://storage/tables/test_table",
+            tblproperties={
+                "delta.minReaderVersion": "2",
+                "delta.minWriterVersion": "5",
+            },
+        )
+
+    @patch.object(Spark, "get")
+    @patch.object(DeltaTableSpec, "compare_to_name")
+    def test_make_storage_match_no_changes(self, mock_compare_to_name, mock_spark_get):
+        """Test that make_storage_match() does nothing if no changes are needed."""
+
+        mock_compare_to_name.return_value.is_different.return_value = False
+
+        self.spec.make_storage_match()
+
+        # Ensure no SQL commands were executed
+        mock_spark_get.return_value.sql.assert_not_called()
+
+    @patch.object(Spark, "get")
+    @patch.object(DeltaTableSpec, "compare_to_name")
+    def test_make_storage_match_add_column(self, mock_compare_to_name, mock_spark_get):
+        """Test that make_storage_match() adds a column when needed."""
+
+        mock_compare_to_name.return_value.is_different.return_value = True
+        mock_compare_to_name.return_value.alter_statements.return_value = [
+            "ALTER TABLE test_db.test_table ADD COLUMN new_col STRING"
+        ]
+
+        self.spec.make_storage_match(allow_columns_add=True)
+
+        # Ensure the correct SQL was executed
+        mock_spark_get.return_value.sql.assert_called_once_with(
+            "ALTER TABLE test_db.test_table ADD COLUMN new_col STRING"
+        )
+
+    @patch.object(Spark, "get")
+    @patch.object(DeltaTableSpec, "compare_to_name")
+    def test_make_storage_match_drop_column(self, mock_compare_to_name, mock_spark_get):
+        """Test that make_storage_match() drops a column when allowed."""
+
+        mock_compare_to_name.return_value.is_different.return_value = True
+        mock_compare_to_name.return_value.alter_statements.return_value = [
+            "ALTER TABLE test_db.test_table DROP COLUMN old_col"
+        ]
+
+        self.spec.make_storage_match(allow_columns_drop=True)
+
+        # Ensure the correct SQL was executed
+        mock_spark_get.return_value.sql.assert_called_once_with(
+            "ALTER TABLE test_db.test_table DROP COLUMN old_col"
+        )
+
+    @patch.object(Spark, "get")
+    @patch.object(DeltaTableSpec, "compare_to_name")
+    def test_make_storage_match_change_column_type(
+        self, mock_compare_to_name, mock_spark_get
+    ):
+        """Test that make_storage_match() alters column types when needed."""
+
+        mock_compare_to_name.return_value.is_different.return_value = True
+        mock_compare_to_name.return_value.alter_statements.return_value = [
+            "ALTER TABLE test_db.test_table ALTER COLUMN some_col TYPE BIGINT"
+        ]
+
+        self.spec.make_storage_match(allow_columns_type_change=True)
+
+        # Ensure the correct SQL was executed
+        mock_spark_get.return_value.sql.assert_called_once_with(
+            "ALTER TABLE test_db.test_table ALTER COLUMN some_col TYPE BIGINT"
+        )
+
+    @patch.object(Spark, "get")
+    @patch.object(DeltaTableSpec, "compare_to_name")
+    def test_make_storage_match_create_table(
+        self, mock_compare_to_name, mock_spark_get
+    ):
+        """Test that make_storage_match() creates the table if it does not exist."""
+
+        # Simulate a missing table by making compare_to_name() return None for base
+        mock_compare_to_name.return_value = DeltaTableSpecDifference(
+            base=None, target=self.spec
+        )
+
+        # Expected CREATE TABLE SQL
+        create_sql = self.spec.get_sql_create()
+
+        # Call make_storage_match with table creation enabled
+        self.spec.make_storage_match(allow_table_create=True)
+
+        # Ensure the CREATE TABLE SQL was executed
+        mock_spark_get.return_value.sql.assert_called_once_with(create_sql)
+
+    @patch.object(Spark, "get")
+    @patch.object(DeltaTableSpec, "compare_to_name")
+    def test_make_storage_match_multiple_changes(
+        self, mock_compare_to_name, mock_spark_get
+    ):
+        """Test that make_storage_match() executes multiple SQL alterations when needed."""
+
+        mock_compare_to_name.return_value.is_different.return_value = True
+        mock_compare_to_name.return_value.alter_statements.return_value = [
+            "ALTER TABLE test_db.test_table ADD COLUMN new_col STRING",
+            "ALTER TABLE test_db.test_table DROP COLUMN old_col",
+            "ALTER TABLE test_db.test_table ALTER COLUMN some_col TYPE BIGINT",
+        ]
+
+        self.spec.make_storage_match(
+            allow_columns_add=True,
+            allow_columns_drop=True,
+            allow_columns_type_change=True,
+        )
+
+        # Convert expected calls into `call()` objects to match actual calls
+        expected_calls = [
+            call("ALTER TABLE test_db.test_table ADD COLUMN new_col STRING"),
+            call("ALTER TABLE test_db.test_table DROP COLUMN old_col"),
+            call("ALTER TABLE test_db.test_table ALTER COLUMN some_col TYPE BIGINT"),
+        ]
+
+        # Ensure all expected SQL commands were executed
+        mock_spark_get.return_value.sql.assert_has_calls(expected_calls, any_order=True)

--- a/tests/local/deltaspec/test_table_spec_uc_location.py
+++ b/tests/local/deltaspec/test_table_spec_uc_location.py
@@ -1,12 +1,9 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from pyspark.sql import Row
-from pyspark.sql.types import (
-    StructType, StructField, StringType, TimestampType,
-    ArrayType, LongType, IntegerType, MapType
-)
+
 from spetlr.deltaspec.DeltaTableSpec import DeltaTableSpec
-from spetlr.spark import Spark
 
 
 class TestDeltaTableSpec(unittest.TestCase):
@@ -15,6 +12,7 @@ class TestDeltaTableSpec(unittest.TestCase):
     https://learn.microsoft.com/en-us/azure/databricks/delta/table-details
 
     """
+
     @patch("spetlr.spark.Spark.get")  # Mock Spark session retrieval
     def test_from_name_with_mocked_describe_detail(self, mock_spark_get):
         """Test DeltaTableSpec.from_name with a mocked DESCRIBE DETAIL output."""
@@ -23,7 +21,6 @@ class TestDeltaTableSpec(unittest.TestCase):
         mock_spark = MagicMock()
         mock_spark_get.return_value = mock_spark
 
-
         # Define the row data as per the example
         mock_row = Row(
             format="delta",
@@ -31,7 +28,7 @@ class TestDeltaTableSpec(unittest.TestCase):
             name="test_catalog.test_db.test_table",
             description=None,
             location="abfss://catalog@heyhey.dfs.core.windows.net/__unitystorage/"
-                     "catalogs/xxx/tables/yyyy",
+            "catalogs/xxx/tables/yyyy",
             createdAt=None,  # Set as None since timestamps are not needed in this test
             lastModified=None,
             partitionColumns=[],
@@ -45,24 +42,28 @@ class TestDeltaTableSpec(unittest.TestCase):
             statistics={"numRowsDeletedByDeletionVectors": 0, "numDeletionVectors": 0},
         )
 
-        # Ensure that spark.sql("DESCRIBE DETAIL ...").collect() returns a **list with a single Row**
+        # Ensure that
+        # spark.sql("DESCRIBE DETAIL ...").collect()
+        # returns a **list with a single Row**
         mock_spark.sql.return_value.collect.return_value = [mock_row]
 
         # Run the test
         spec = DeltaTableSpec.from_name("testcatalog.test_db.test_table")
 
         # Assert that the location is set to None for managed tables
-        self.assertIsNone(spec.location, "The location should be None for managed Unity Catalog tables.")
+        self.assertIsNone(
+            spec.location,
+            "The location should be None " "for managed Unity Catalog tables.",
+        )
         self.assertEqual(spec.name, "test_catalog.test_db.test_table")
         self.assertIsNone(spec.comment)  # Description is mapped to `comment`
         self.assertEqual(spec.partitioned_by, [])
         self.assertEqual(spec.cluster_by, [])
-        self.assertEqual(spec.tblproperties, {
-            "delta.enableDeletionVectors": "true",
-            "delta.minReaderVersion": "3",
-            "delta.minWriterVersion": "7"
-        })
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self.assertEqual(
+            spec.tblproperties,
+            {
+                "delta.enableDeletionVectors": "true",
+                "delta.minReaderVersion": "3",
+                "delta.minWriterVersion": "7",
+            },
+        )

--- a/tests/local/deltaspec/test_table_spec_uc_location.py
+++ b/tests/local/deltaspec/test_table_spec_uc_location.py
@@ -1,0 +1,68 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from pyspark.sql import Row
+from pyspark.sql.types import (
+    StructType, StructField, StringType, TimestampType,
+    ArrayType, LongType, IntegerType, MapType
+)
+from spetlr.deltaspec.DeltaTableSpec import DeltaTableSpec
+from spetlr.spark import Spark
+
+
+class TestDeltaTableSpec(unittest.TestCase):
+    """
+    The detail schema can be found here:
+    https://learn.microsoft.com/en-us/azure/databricks/delta/table-details
+
+    """
+    @patch("spetlr.spark.Spark.get")  # Mock Spark session retrieval
+    def test_from_name_with_mocked_describe_detail(self, mock_spark_get):
+        """Test DeltaTableSpec.from_name with a mocked DESCRIBE DETAIL output."""
+
+        # Mock Spark session
+        mock_spark = MagicMock()
+        mock_spark_get.return_value = mock_spark
+
+
+        # Define the row data as per the example
+        mock_row = Row(
+            format="delta",
+            id="04e1db34-399c-42d8-8c56-a7311f60e73d",
+            name="test_catalog.test_db.test_table",
+            description=None,
+            location="abfss://catalog@heyhey.dfs.core.windows.net/__unitystorage/"
+                     "catalogs/xxx/tables/yyyy",
+            createdAt=None,  # Set as None since timestamps are not needed in this test
+            lastModified=None,
+            partitionColumns=[],
+            clusteringColumns=[],
+            numFiles=0,
+            sizeInBytes=0,
+            properties={"delta.enableDeletionVectors": "true"},
+            minReaderVersion=3,
+            minWriterVersion=7,
+            tableFeatures=["deletionVectors"],
+            statistics={"numRowsDeletedByDeletionVectors": 0, "numDeletionVectors": 0},
+        )
+
+        # Ensure that spark.sql("DESCRIBE DETAIL ...").collect() returns a **list with a single Row**
+        mock_spark.sql.return_value.collect.return_value = [mock_row]
+
+        # Run the test
+        spec = DeltaTableSpec.from_name("testcatalog.test_db.test_table")
+
+        # Assert that the location is set to None for managed tables
+        self.assertIsNone(spec.location, "The location should be None for managed Unity Catalog tables.")
+        self.assertEqual(spec.name, "test_catalog.test_db.test_table")
+        self.assertIsNone(spec.comment)  # Description is mapped to `comment`
+        self.assertEqual(spec.partitioned_by, [])
+        self.assertEqual(spec.cluster_by, [])
+        self.assertEqual(spec.tblproperties, {
+            "delta.enableDeletionVectors": "true",
+            "delta.minReaderVersion": "3",
+            "delta.minWriterVersion": "7"
+        })
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Refactor
- (and more tests)

## Description

### Overview
This PR introcues a handling of a unity catalog location for a table.
The location for the deltatablespec is actually external location - and unity catalog tables have no external location

### What is the current behavior?
Today, UC tables are not handled - the location is extracted, but it is a UC location - not external.

### What is the new behavior?
Simply by searching for ""__unitystorage/catalogs" in the location - we set it to None

### Does this PR introduce a breaking change?
If any have used the deltaspec, and use the extracted location as an actual location for access directly or such - it will break!
