### PR TITLE
Feature/regex ignore config

### DIFF
--- a/tests/local/configurator/test_configurator_recursion.py
+++ b/tests/local/configurator/test_configurator_recursion.py
@@ -4,12 +4,10 @@ from spetlr import Configurator
 
 
 class TestConfigurator(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        Configurator().clear_all_configurations()
 
     def test_01_recursion(self):
         tc = Configurator()
+        tc.clear_all_configurations()
         tc.register("BASE", "foobar")
         tc.register("FIRST", "really {BASE}")
         print(tc.get("FIRST"))

--- a/tests/local/deltaspec/test_table_spec_helper_defs.py
+++ b/tests/local/deltaspec/test_table_spec_helper_defs.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from pyspark.sql import DataFrame, Row
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
+from spetlr import Configurator
 from spetlr.delta import DeltaHandle
 from spetlr.deltaspec import DeltaTableSpecBase
 from spetlr.deltaspec.DeltaTableSpec import DeltaTableSpec
@@ -15,6 +16,7 @@ class TestDeltaTableSpecMethods(unittest.TestCase):
 
     def setUp(self):
         """Setup a sample DeltaTableSpec object."""
+        Configurator().clear_all_configurations()
         self.schema = StructType(
             [
                 StructField("id", IntegerType(), True),

--- a/tests/local/sql/sql/test_location.sql
+++ b/tests/local/sql/sql/test_location.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS some.table
+(hi int)
+LOCATION somepath/;
+
+CREATE TABLE IF NOT EXISTS some.other
+(there int)
+;

--- a/tests/local/sql/sql/test_regex.sql
+++ b/tests/local/sql/sql/test_regex.sql
@@ -1,0 +1,41 @@
+-- spetlr.Configurator key: TestDb
+CREATE DATABASE IF NOT EXISTS my_test_db
+COMMENT "Test Database"
+LOCATION "/tmp/foo/bar/my_test_db/"
+WITH DBPROPERTIES ("property_name"="property_value");
+
+-- COMMAND ----------
+
+-- spetlr.Configurator key: TestTable
+CREATE TABLE IF NOT EXISTS my_test_db.test_table
+(
+  id INT,
+  value STRING
+  -- comment with a semicolon ;
+)
+USING DELTA
+COMMENT "Test table with a location"
+LOCATION "/mnt/foo/bar/my_test_db/test_table/";
+
+-- spetlr.Configurator key: AnotherTable
+CREATE TABLE IF NOT EXISTS my_test_db.another_table
+(
+  name STRING,
+  age INT
+)
+USING DELTA
+COMMENT "Another test table"
+LOCATION "/mnt/foo/bar/my_test_db/another_table/";
+
+-- This should be removed by regex
+DROP TABLE my_test_db.dropped_table;
+
+-- spetlr.Configurator key: PlaceholderExample
+CREATE TABLE IF NOT EXISTS my_test_db.config_table
+(
+  config_name STRING,
+  config_value STRING
+)
+USING DELTA
+COMMENT "Config table"
+LOCATION "/{MNT}/foo/bar/my_test_db/config_table/";

--- a/tests/local/sql/test_SqlExecutor.py
+++ b/tests/local/sql/test_SqlExecutor.py
@@ -1,5 +1,7 @@
 import unittest
+from textwrap import dedent
 
+from spetlr import Configurator
 from spetlr.sql import SqlExecutor
 from tests.local.sql import sql
 
@@ -7,17 +9,17 @@ from tests.local.sql import sql
 class TestSqlExecutor(unittest.TestCase):
     def test_01_standard_splitting(self):
         s = SqlExecutor(sql)
-        statements = list(s.get_statements("*"))
+        statements = list(s.get_statements("test1"))
         self.assertEqual(len(statements), 3)
 
     def test_02_marker_splitting(self):
         s = SqlExecutor(sql, statement_spliter=["-- COMMAND ----------"])
-        statements = list(s.get_statements("*"))
+        statements = list(s.get_statements("test1"))
         self.assertEqual(len(statements), 2)
 
     def test_03_no_splitting(self):
         s = SqlExecutor(sql, statement_spliter=None)
-        statements = list(s.get_statements("*"))
+        statements = list(s.get_statements("test1"))
         self.assertEqual(len(statements), 1)
 
     def test_04_file_by_name(self):
@@ -34,3 +36,182 @@ class TestSqlExecutor(unittest.TestCase):
         s = SqlExecutor(sql, statement_spliter=None, ignore_empty_folder=True)
         statements = list(s.get_statements("unknown"))
         self.assertEqual(len(statements), 0)
+
+    def test_06_remove_location(self):
+        statement_with_location = """
+        create table if not exists heyson
+        (col int)
+        LOCATION {SOME_PATH}
+        """
+        expected_statement = """
+        create table if not exists heyson
+        (col int)
+        """
+
+        sqlExe = SqlExecutor(ignore_location=True)
+
+        result = sqlExe._handle_line_regex(statement_with_location)
+
+        self.assertEqual(result, expected_statement)
+
+    def test_07_no_matching_lines(self):
+        statement_without_match = """
+        create table if not exists my_table
+        (id int, name string)
+        """
+
+        expected_statement = """
+        create table if not exists my_table
+        (id int, name string)
+        """
+
+        sqlExe = SqlExecutor(ignore_lines_regex=["DROP", "USE"])
+
+        result = sqlExe._handle_line_regex(statement_without_match)
+
+        self.assertEqual(result, expected_statement)
+
+    def test_09_partial_match_not_removed(self):
+        statement_with_partial_match = """
+        create table if not exists my_table
+        (id int, name string);
+        LOCATIONS should be specified here
+        """
+
+        expected_statement = """
+        create table if not exists my_table
+        (id int, name string);
+        LOCATIONS should be specified here
+        """
+
+        sqlExe = SqlExecutor(ignore_location=True)
+
+        result = sqlExe._handle_line_regex(statement_with_partial_match)
+
+        self.assertEqual(result, expected_statement)
+
+    def test_11_file_by_name_remove_location(self):
+        sqlexe = SqlExecutor(sql, statement_spliter=None, ignore_location=True)
+
+        statements = sqlexe.get_statements("test1")
+        _all = [x.strip() for x in statements]  # Stripping for clean comparison
+
+        for a in _all:
+            if "LOCATION" in a:
+                raise Exception("LOCATION found!")
+
+    def test_12_file_by_name_semicolon_after_location(self):
+        sqlexe = SqlExecutor(sql, ignore_location=True)
+
+        statements = list(sqlexe.get_statements("test_location"))
+
+        self.assertEqual(len(statements), 2)
+
+        expected1 = """
+        CREATE TABLE IF NOT EXISTS some.table
+        (hi int)"""
+
+        self.assertEqual(dedent(statements[0]).strip(), dedent(expected1).strip())
+
+        expected2 = """
+        CREATE TABLE IF NOT EXISTS some.other
+        (there int)
+        ;"""
+
+        self.assertEqual(dedent(statements[1]).strip(), dedent(expected2).strip())
+
+    def test_13_no_changes_if_no_ignore(self):
+        """
+        This test ensures that all are preserved correctly
+        even if no ignores are defined
+        """
+
+        sqlexe = SqlExecutor(sql)
+        statements = list(sqlexe.get_statements("test_location"))
+
+        self.assertEqual(len(statements), 2)
+
+        expected1 = """
+        CREATE TABLE IF NOT EXISTS some.table
+        (hi int)
+        LOCATION somepath/;"""
+
+        expected2 = """
+        \n\n
+        CREATE TABLE IF NOT EXISTS some.other
+        (there int)
+        ;
+        """
+
+        self.assertEqual(dedent(statements[0]).strip(), dedent(expected1).strip())
+
+        self.assertEqual(dedent(statements[1]).strip(), dedent(expected2).strip())
+
+    def test_14_ignore_location_lines(self):
+        self._setup_clear_conf()
+        sqlexe = SqlExecutor(sql, ignore_location=True)
+
+        sql_statement = """
+        CREATE TABLE IF NOT EXISTS my_test_db.table1
+        (
+          id INT
+        )
+        LOCATION "/mnt/foo/bar/my_test_db/table1/";
+        """
+        cleaned_sql = list(sqlexe.chop_and_substitute(sql_statement))
+        self.assertNotIn("LOCATION", cleaned_sql[0])
+
+    def test_replace_curly_bracket_placeholders(self):
+        """Test replacement of {MNT} in SQL using Configurator."""
+        self._setup_clear_conf()
+        sqlexe = SqlExecutor(sql)
+        sql_statement = """
+           CREATE TABLE IF NOT EXISTS my_test_db.test
+           (
+             id INT
+           )
+           LOCATION "/{MNT}/foo/bar/my_test_db/test/";
+           """
+        cleaned_sql = list(sqlexe.chop_and_substitute(sql_statement))
+        self.assertIn("/mnt/test/path/foo/bar/my_test_db/test/", cleaned_sql[0])
+
+    def test_ignore_multiple_patterns(self):
+        """Test multiple regex patterns for filtering lines."""
+
+        self._setup_clear_conf()
+        sqlexe = SqlExecutor(
+            sql, ignore_lines_regex=[r"^LOCATION\b.*", r"^-- spetlr.*"]
+        )
+
+        sql_statement = """
+        -- spetlr.Configurator key: TestTable
+        CREATE TABLE IF NOT EXISTS my_test_db.test
+        (
+          id INT
+        )
+        LOCATION "/mnt/foo/bar/my_test_db/test/";
+        """
+        cleaned_sql = list(sqlexe.chop_and_substitute(sql_statement))
+        self.assertNotIn("LOCATION", cleaned_sql[0])
+        self.assertNotIn("spetlr.Configurator", cleaned_sql[0])
+
+    def test_ignore_table_drops(self):
+        """Test filtering out DROP TABLE statements."""
+
+        self._setup_clear_conf()
+        sqlexe = SqlExecutor(sql, ignore_lines_regex=[r"^DROP TABLE.*"])
+
+        sql_statement = """
+        DROP TABLE my_test_db.old_table;
+        CREATE TABLE IF NOT EXISTS my_test_db.new_table
+        (
+          name STRING
+        );
+        """
+        cleaned_sql = list(sqlexe.chop_and_substitute(sql_statement))
+        self.assertNotIn("DROP TABLE", cleaned_sql[0])
+        self.assertIn("CREATE TABLE", cleaned_sql[0])
+
+    def _setup_clear_conf(self):
+        Configurator().clear_all_configurations()
+        Configurator().register("MNT", "/mnt/test/path")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Refactor
- Feature

## Description

### Overview
This PR introduces a new parameter to the SqlExecutor.
It makes it possible to ignore (remove) lines that matches a specific regex.

### What is the new behavior?
If you set the ignore_lines_regex or ignore_location in the configurator, when the sql is parsed, the executor will remove those lines.

### Does this PR introduce a breaking change?
YES! If you have choose to ignore a pattern, which also a part of your schema.
Lets say you want to ignore "LOCATION".
But, LOCATION is also a name in a schema, the column in that schema is ignored.
