### PR TITLE
Make configurator thread-safe

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 24.8.0
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.10
 -   repo: https://github.com/PyCQA/flake8
     rev: 7.1.1
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ console_scripts =
 	spetlr_task = spetlr.entry_points.generalized_task_entry_point:main
 
 [flake8]
-exclude = .git,__pycache__,docs,build,dist,venv
+exclude = .git,__pycache__,docs,build,dist,venv,.venv
 max-line-length = 88
 extend-ignore = E203
 per-file-ignores = __init__.py:F401

--- a/src/spetlr/configurator/configurator.py
+++ b/src/spetlr/configurator/configurator.py
@@ -199,7 +199,9 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
                 # keys without _ are handled below
 
                 value = self._get_item_property(
-                    id_part, property_part, _forbidden_keys.copy()
+                    id_part,
+                    property_part,
+                    _forbidden_keys.copy(),
                 )
                 # raises ValueError if it does not exist
 
@@ -211,14 +213,18 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
             # if we get here, there was no _ in the key. Either the key exists as a bare
             # string value, try that:
             try:
-                replacements[key] = self._get_item_property(key, "", _forbidden_keys)
+                replacements[key] = self._get_item_property(
+                    key, "", _forbidden_keys.copy()
+                )
                 continue
             except NoSuchValueException:
                 pass
 
             # otherwise bare key references are to 'name',
             # which _must_ exist in this case
-            replacements[key] = self._get_item_property(key, "name", _forbidden_keys)
+            replacements[key] = self._get_item_property(
+                key, "name", _forbidden_keys.copy()
+            )
 
         # we have run through the key names of all replacement keys in the string.
         # Any that we could not find were skipped silently above, but that means that

--- a/src/spetlr/configurator/configurator.py
+++ b/src/spetlr/configurator/configurator.py
@@ -390,7 +390,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         """The distinction between extras and normal values was removed.
         This method will always return an empty dict. Extra settings are now
         string items. Retrieve them with .get(id)"""
-        self.deprecated()
+        self._deprecated()
 
         return {}
 
@@ -417,7 +417,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         with self._lock:
             return self._key_of(attribute, value)
 
-    def deprecated(self):
+    def _deprecated(self):
         if self.deprecation_errors:
             raise DeprecationException(
                 "A deprecated feature was used and deprecation_errors was set to True."
@@ -429,7 +429,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
     def set_extra(self, **kwargs: str):
         """Use .register(key,value) instead.
         for example call .register('ENV','prod')"""
-        self.deprecated()
+        self._deprecated()
 
         with self._lock:
             for key, value in kwargs.items():
@@ -504,7 +504,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         :param table_id: Table id in the .json or .yaml files.
         :return: str: table path
         """
-        self.deprecated()
+        self._deprecated()
         with self._lock:
             return self._get(table_id, "path")
 
@@ -552,7 +552,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
             if the property is missing.
         :return: str: property value
         """
-        self.deprecated()
+        self._deprecated()
 
         property_value = self.get_all_details().get(
             f"{table_id}_{property_name}", default_value

--- a/src/spetlr/configurator/configurator.py
+++ b/src/spetlr/configurator/configurator.py
@@ -248,11 +248,11 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
                         for key, value in update.items():
                             # we now support all bare value types in yaml.
                             # no further checking
-                            self.register(key, value)
+                            self._register(key, value)
 
             # try re-building all details
             if consistency_check:
-                self.verify_consistency()
+                self._verify_consistency()
         except:  # noqa: E722  we re-raise the exception, so bare except is ok.
             # this piece makes it so that the Configurator can still be used
             # if any exception raised by the above code is caught.
@@ -265,10 +265,10 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         self.table_details = dict()
 
         for key, value in _parse_sql_to_config(resource_path).items():
-            self.register(key, value)
+            self._register(key, value)
 
         if consistency_check:
-            self.verify_consistency()
+            self._verify_consistency()
 
     def _key_of(self, attribute: str, value: str) -> str:
 
@@ -322,7 +322,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
 
     def _regenerate_unique_id_and_clear_conf(self):
         self._unique_id = uuid.uuid4().hex
-        self.clear_all_configurations()
+        self._clear_all_configurations()
 
     def _get_all_details(self):
 
@@ -332,20 +332,20 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
             for table_id in self._raw_resource_details.keys():
                 # add the name as the bare key
                 try:
-                    self.table_details[table_id] = self.get(table_id)
+                    self.table_details[table_id] = self._get(table_id)
                     continue  # if it was a bare string, we can stop here
                 except NoSuchValueException:
                     pass
 
                 try:
-                    self.table_details[table_id] = self.get(table_id, "name")
+                    self.table_details[table_id] = self._get(table_id, "name")
                 except NoSuchValueException:
                     pass
 
                 # add every property as a _property part
                 for property_name in set(self._get_item(table_id).keys()):
                     try:
-                        item = self.get(table_id, property_name)
+                        item = self._get(table_id, property_name)
                     except NoSuchValueException:
                         continue
                     # if the dict values are dicts, stop here,
@@ -370,19 +370,19 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
 
     def clear_all_configurations(self):
         with self._lock:
-            self._clear_all_configurations()
+            return self._clear_all_configurations()
 
     def all_keys(self):
         """All keys that appear in the configuration files."""
         with self._lock:
-            self._all_keys()
+            return self._all_keys()
 
     def verify_consistency(self):
         """This method will re-build the table details. This requires that all
         internally recursive references can be resolved."""
 
         with self._lock:
-            self._verify_consistency()
+            return self._verify_consistency()
 
     @deprecated(
         reason="use .get('ENV') to get literal values.",
@@ -399,13 +399,13 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         self, resource_path: Union[str, ModuleType], consistency_check=True
     ) -> None:
         with self._lock:
-            self._add_resource_path(resource_path, consistency_check)
+            return self._add_resource_path(resource_path, consistency_check)
 
     def add_sql_resource_path(
         self, resource_path: Union[str, ModuleType], consistency_check=True
     ) -> None:
         with self._lock:
-            self._add_sql_resource_path(resource_path, consistency_check)
+            return self._add_sql_resource_path(resource_path, consistency_check)
 
     def key_of(self, attribute: str, value: str) -> str:
         """Obtain the key of the first registered item that has a given attribute
@@ -439,12 +439,12 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
     def set_debug(self, deprecation_errors=False):
         """Select debug tables. {ID} will be replaced with a guid"""
         with self._lock:
-            self.__reset(debug=True, deprecation_errors=deprecation_errors)
+            return self.__reset(debug=True, deprecation_errors=deprecation_errors)
 
     def set_prod(self):
         """Select production tables. {ID} will be replaced with a empty string"""
         with self._lock:
-            self.__reset(debug=False, deprecation_errors=False)
+            return self.__reset(debug=False, deprecation_errors=False)
 
     def reset(self, *, debug: bool = False, deprecation_errors=False):
         """
@@ -454,7 +454,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         :param kwargs: additional keys to be substituted in names and paths
         """
         with self._lock:
-            self.__reset(debug, deprecation_errors=deprecation_errors)
+            return self.__reset(debug, deprecation_errors=deprecation_errors)
 
     def is_debug(self):
         """
@@ -516,7 +516,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         Return value will be whatever was registered under the given property."""
 
         with self._lock:
-            return self.get(table_id, property, default=default)
+            return self._get(table_id, property, default=default)
 
     def get_all_details(self):
         """

--- a/src/spetlr/configurator/configurator.py
+++ b/src/spetlr/configurator/configurator.py
@@ -51,6 +51,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         self,
         resource_path: Union[str, ModuleType] = None,
     ):
+        self._lock = threading.Lock()
         self._unique_id = uuid.uuid4().hex
         self.deprecation_errors = False
 

--- a/src/spetlr/configurator/configurator.py
+++ b/src/spetlr/configurator/configurator.py
@@ -357,7 +357,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
 
     def _get(self, table_id: str, property: str = "", default: Any = _DEFAULT):
         try:
-                return self._get_item_property(table_id, property)
+            return self._get_item_property(table_id, property)
         except NoSuchValueException:
             if default is self._DEFAULT:
                 raise

--- a/src/spetlr/configurator/configurator.py
+++ b/src/spetlr/configurator/configurator.py
@@ -59,8 +59,8 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         if resource_path:
             self.add_resource_path(resource_path)
 
-    #########################################
-    ## Internal methods - use no lock, not thead-safe on their own.
+    # =============================================================
+    # == Internal methods - use no lock, not thead-safe on their own.
 
     def _all_keys(self):
         return list(self._raw_resource_details.keys())
@@ -364,8 +364,8 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
             else:
                 return default
 
-    #########################################
-    ## Interface methods - use lock, can be used in threaded context
+    # ================================================================
+    # == Interface methods - use lock, can be used in threaded context
 
     def clear_all_configurations(self):
         with self._lock:

--- a/src/spetlr/exceptions/configurator_exceptions.py
+++ b/src/spetlr/exceptions/configurator_exceptions.py
@@ -11,3 +11,7 @@ class SpetlrConfiguratorInvalidSqlException(SpetlrConfiguratorException):
 
 class SpetlrConfiguratorInvalidSqlCommentsException(SpetlrConfiguratorException):
     pass
+
+
+class DeprecationException(SpetlrException):
+    pass

--- a/tests/local/configurator/test_configurator_recursion.py
+++ b/tests/local/configurator/test_configurator_recursion.py
@@ -14,5 +14,6 @@ class TestConfigurator(unittest.TestCase):
         tc.register("FIRST", "really {BASE}")
         print(tc.get("FIRST"))
 
-        tc.register("SECOND", " {BASE} really {FIRST}")
+        tc.register("SECOND", "{BASE}, really {FIRST}")
+        print(tc._raw_resource_details)
         print(tc.get("SECOND"))

--- a/tests/local/configurator/test_configurator_threading.py
+++ b/tests/local/configurator/test_configurator_threading.py
@@ -1,0 +1,42 @@
+import threading
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+from spetlr import Configurator
+from tests.local.configurator import tables1
+
+
+class TestConfigurator(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        Configurator().clear_all_configurations()
+
+    def test_01_import_config(self):
+        tc = Configurator()
+        tc.add_resource_path(tables1)
+
+        tc.reset(debug=True)
+        self.assertRegex(tc.table_name("MyFirst"), "first__.*")
+        self.assertRegex(tc.table_name("MyAlias"), "first__.*")
+        self.assertRegex(tc.table_name("MyForked"), "another")
+
+        tc.reset(debug=False)
+        self.assertRegex(tc.table_name("MyFirst"), "first")
+        self.assertRegex(tc.table_name("MyAlias"), "first")
+        self.assertRegex(tc.table_name("MyForked"), "first")
+
+    def test_02_threading(self):
+        tc = Configurator()
+        tc.set_prod()
+
+        def register_and_check(index):
+            thread = threading.current_thread()
+            unique = f"{index}"
+            tc.register(thread.name, unique)
+            assert tc.get(thread.name) == unique
+
+        with ThreadPoolExecutor() as executor:
+            executor.map(register_and_check, range(100_000))
+
+        # initial registrations still work
+        self.assertRegex(tc.table_name("MyFirst"), "first")


### PR DESCRIPTION
Closes #202

The Configurator was not thread safe and this caused issues.

- Separate all interface from all internal methods.
- sometimes it is necessary to split even simple methods into interface+internal.
- An interface method must take the lock and then never call another interface method.
- An internal method must not touch the lock, that is handled by interface methods.
- Internal methods must never call interface methods, only other internal methods.
- Only internal methods can recurse.

This guide allows us to guarantee that:
- all code that looks at internal data is behind a lock
- all interface methods take the lock.
- the lock is never taken twice, which would result in dead-lock.

This is a pure internal refacturing with no change in interface or functionality.
 
## What type of PR is this? (check all applicable)

- Bug Fix
