### PR TITLE
pure python connection string encryption

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
   urllib3
   msal
   pandas
+  pycryptodome
 
 [options.packages.find]
 where = src

--- a/src/spetlr/eh/EventHubStream.py
+++ b/src/spetlr/eh/EventHubStream.py
@@ -2,7 +2,9 @@
 
 from pyspark.sql import DataFrame
 
-from spetlr.spark import Spark
+from spetlr.eh.EventhubStreamConnectionStringEncrypt import (
+    EventhubStreamConnectionStringEncrypt,
+)
 
 
 class EventHubStream:
@@ -12,6 +14,7 @@ class EventHubStream:
         entity_path: str,
         consumer_group: str,
         max_events_per_trigger: int = 1_000_000,
+        SparkConnectorVersion: str = "2.3.22",
     ):
         """
         Initializes an Azure EventHub.
@@ -30,9 +33,9 @@ class EventHubStream:
 
         unencrypted = "{};EntityPath={}".format(connection_str, entity_path)
         # noinspection PyProtectedMember
-        encrypted = Spark.get()._jvm.org.apache.spark.eventhubs.EventHubsUtils.encrypt(
-            unencrypted
-        )
+        encrypted = EventhubStreamConnectionStringEncrypt(
+            SparkConnectorVersion
+        ).encrypt(unencrypted)
         self.max_events_per_trigger = max_events_per_trigger
         self.config = {
             "eventhubs.consumerGroup": consumer_group,

--- a/src/spetlr/eh/EventhubStreamConnectionStringEncrypt.py
+++ b/src/spetlr/eh/EventhubStreamConnectionStringEncrypt.py
@@ -1,0 +1,52 @@
+import base64
+from hashlib import pbkdf2_hmac
+
+from Crypto.Cipher import AES
+
+
+class EventhubStreamConnectionStringEncrypt:
+    """
+    For connecting to an eventhub stream using the library
+
+    "com.microsoft.azure:azure-eventhubs-spark_2.12:2.3.22"
+
+    This class replaces the need to call the protected method
+
+    >>> spark._jvm.org.apache.spark.eventhubs.EventHubsUtils.encrypt
+
+    You need to supply the SparkConnectorVersion
+    (last part of the library that you installed)
+    """
+
+    def __init__(self, SparkConnectorVersion: str = "2.3.22"):
+        self.key = self._derive_key(SparkConnectorVersion)
+        self.mode: AES.MODE_ECB = AES.MODE_ECB
+        self.block_size: int = 16
+
+    def _pad(self, byte_array: bytearray):
+        """
+        pkcs5 padding
+        """
+        pad_len = self.block_size - len(byte_array) % self.block_size
+        return byte_array + (bytes([pad_len]) * pad_len)
+
+    def _derive_key(self, SparkConnectorVersion: str) -> bytes:
+        return pbkdf2_hmac(
+            hash_name="sha256",
+            password=SparkConnectorVersion.encode(),
+            salt=SparkConnectorVersion.encode(),
+            iterations=1000,
+            dklen=32,
+        )
+
+    def encrypt(self, message: str) -> str:
+        # convert to bytes
+        byte_array = message.encode("UTF-8")
+        # pad the message - with pkcs5 style
+        padded = self._pad(byte_array)
+        # new instance of AES with encoded key
+        cipher = AES.new(self.key, AES.MODE_ECB)
+        # now encrypt the padded bytes
+        encrypted = cipher.encrypt(padded)
+        # base64 encode and convert back to string
+        return base64.b64encode(encrypted).decode("utf-8")


### PR DESCRIPTION
We used to have a call to a protected java method. This caused problems on Unity clusters where code protection features prevent this. I re-implemented the connection encryption in pure python to get the same result:

- I used standard crypto libraries for every sensitive transformation.
- There seems to be no library support for padding like in java, but the code seems so simple that I trust the code that I copied from online forums.
- I confirmed experimentally that the code works for me