### PR TITLE
configurator supports all values

### DIFF
--- a/src/spetlr/configurator/configurator.py
+++ b/src/spetlr/configurator/configurator.py
@@ -561,12 +561,7 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         """
         self._deprecated()
 
-        property_value = self.get_all_details().get(
-            f"{table_id}_{property_name}", default_value
-        )
+        if default_value is None:
+            default_value = self._DEFAULT
 
-        if property_value is None:
-            raise ValueError(
-                f"property '{property_name}' for table identifier '{table_id}' is empty"
-            )
-        return property_value
+        return self.get(table_id, property_name, default=default_value)

--- a/tests/local/configurator/test_configurator.py
+++ b/tests/local/configurator/test_configurator.py
@@ -470,3 +470,16 @@ class TestConfigurator(unittest.TestCase):
             c.register("somekey")
 
         self.assertIn("missing 1 required positional argument", str(cm.exception))
+
+    def test_value_types(self):
+        """Test registration and retrieval of arbitrary value types."""
+        c = Configurator()
+        c.clear_all_configurations()
+        c.add_sql_resource_path(views)
+
+        c.register("somekey", ["a", "b", "c"])
+        arr = c.get("somekey")
+        self.assertEqual(arr[0], "a")
+
+        self.assertEqual(c.get("MyArrayObject", "array"), ["hello", "world"])
+        self.assertEqual(c.get("MyArrayObject", "object"), {"nested": "foobar"})

--- a/tests/local/configurator/views/view.sql
+++ b/tests/local/configurator/views/view.sql
@@ -4,3 +4,12 @@ CREATE OR REPLACE TEMPORARY VIEW IF NOT EXISTS SomeViewName
 COMMENT 'Better than a clock'
 TBLPROPERTIES ('m.prop'='hello')
 AS SELECT current_date();
+
+-- SPETLR.CONFIGURATOR key: MyArrayObject
+-- SPETLR.CONFIGURATOR array:
+-- SPETLR.CONFIGURATOR  - hello
+-- SPETLR.CONFIGURATOR  - world
+-- SPETLR.CONFIGURATOR object:
+-- SPETLR.CONFIGURATOR   nested: foobar
+
+;


### PR DESCRIPTION
Closes #201 

This PR adds tests that check that the Configurator supports complex values, such as arrays and dictionaries. The deprecated method `.table_property` is now simply an alias for `.get`.