### PR TITLE
Give better error messages on missing keys

### DIFF
--- a/src/spetlr/configurator/configurator.py
+++ b/src/spetlr/configurator/configurator.py
@@ -515,6 +515,16 @@ class Configurator(ConfiguratorCli, metaclass=ConfiguratorSingleton):
         with self._lock:
             return self._get(table_id, "path")
 
+    def __contains__(self, item):
+        """Returns true if 'item' is available as a key."""
+        # This allows the operation `'key' in Configurator()`
+        return item in self._raw_resource_details
+
+    def assert_contains(self, item):
+        """Asserts that 'item' is available as a key."""
+        if item not in self._raw_resource_details:
+            raise KeyError(f"{item} is not a known key")
+
     def get(self, table_id: str, property: str = "", default: Any = _DEFAULT):
         """return the property of the table_id.
         To get raw strings, specify no property.

--- a/src/spetlr/cosmos/cosmos.py
+++ b/src/spetlr/cosmos/cosmos.py
@@ -206,6 +206,7 @@ class CosmosDb(CosmosBaseServer):
 
     def from_tc(self, table_id: str) -> CosmosHandle:
         tc = Configurator()
+        tc.assert_contains(table_id)
         name = tc.table_name(table_id)
         rows_per_partition = tc.get(table_id, "rows_per_partition", "")
         rows_per_partition = int(rows_per_partition) if rows_per_partition else None

--- a/src/spetlr/delta/db_handle.py
+++ b/src/spetlr/delta/db_handle.py
@@ -26,6 +26,7 @@ class DbHandle:
     @classmethod
     def from_tc(cls, id: str):
         tc = Configurator()
+        tc.assert_contains(id)
         return cls(
             name=tc.table_name(id),
             location=tc.get(id, "path", ""),

--- a/src/spetlr/delta/delta_handle.py
+++ b/src/spetlr/delta/delta_handle.py
@@ -85,6 +85,7 @@ class DeltaHandle(TableHandle):
     @classmethod
     def from_tc(cls, id: str) -> "DeltaHandle":
         tc = Configurator()
+        tc.assert_contains(id)
         return cls(
             name=tc.get(id, "name", ""),
             location=tc.get(id, "path", ""),

--- a/src/spetlr/deltaspec/DeltaDatabaseSpec.py
+++ b/src/spetlr/deltaspec/DeltaDatabaseSpec.py
@@ -61,6 +61,7 @@ class DeltaDatabaseSpec:
         """Build a DeltaDatabaseSpec instance from what is in the Configurator.
         This may have previously been parsed from sql."""
         c = Configurator()
+        c.assert_contains(id)
         try:
             name = c.get(id, "name")
         except NoSuchValueException:

--- a/src/spetlr/deltaspec/DeltaTableSpec.py
+++ b/src/spetlr/deltaspec/DeltaTableSpec.py
@@ -68,6 +68,7 @@ class DeltaTableSpec(DeltaTableSpecBase):
     @classmethod
     def from_tc(cls, id: str) -> "DeltaTableSpec":
         c = Configurator()
+        c.assert_contains(id)
         # schema is required
         item = c._get_item(id)
         schema = get_schema(item["schema"]["sql"])

--- a/src/spetlr/eh/EventHubCapture.py
+++ b/src/spetlr/eh/EventHubCapture.py
@@ -37,6 +37,7 @@ class EventHubCapture:
     @classmethod
     def from_tc(cls, id: str):
         tc = Configurator()
+        tc.assert_contains(id)
         return cls(
             name=tc.get(id, "name"),
             path=tc.get(id, "path"),

--- a/src/spetlr/eh/EventHubCaptureExtractor.py
+++ b/src/spetlr/eh/EventHubCaptureExtractor.py
@@ -27,6 +27,7 @@ class EventHubCaptureExtractor:
     @classmethod
     def from_tc(cls, tbl_id: str):
         tc = Configurator()
+        tc.assert_contains(tbl_id)
         assert tc.get(tbl_id, "format") == "avro"
         return cls(
             path=tc.get(tbl_id, "path"),

--- a/src/spetlr/filehandle/file_handle.py
+++ b/src/spetlr/filehandle/file_handle.py
@@ -61,6 +61,7 @@ class FileHandle(TableHandle):
     @classmethod
     def from_tc(cls, id: str) -> "FileHandle":
         tc = Configurator()
+        tc.assert_contains(id)
         sm = SchemaManager()
         return cls(
             file_location=tc.get(id, "path"),

--- a/src/spetlr/sql/SqlServer.py
+++ b/src/spetlr/sql/SqlServer.py
@@ -178,6 +178,7 @@ class SqlServer(SqlBaseServer):
         """This method allows an instance of SqlServer to be a drop in for the class
         DeltaHandle. One can call from_tc(id) on either to get a table handle."""
         tc = Configurator()
+        tc.assert_contains(id)
         return SqlHandle(name=tc.table_name(id), sql_server=self)
 
     get_handle = from_tc


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Feature

## Description

Often when instantiating DeltaHandle.from_tc(mykey) you can get an error like "Cannot create DeltaHandle without name or location". This is confusing when what really happened is that the configurator was not populated with values. This new PR adds an assert that checks if the given table ID even exists in the configurator. 
