### PR TITLE
enable cosmos upsert

### DIFF
--- a/src/spetlr/cosmos/cosmos.py
+++ b/src/spetlr/cosmos/cosmos.py
@@ -220,4 +220,5 @@ class CosmosDb(CosmosBaseServer):
             cosmos_db=self,
             schema=schema,
             rows_per_partition=rows_per_partition,
+            partition_key=tc.get(table_id, "partition_key", None),
         )

--- a/src/spetlr/cosmos/cosmos_handle.py
+++ b/src/spetlr/cosmos/cosmos_handle.py
@@ -27,11 +27,16 @@ class CosmosHandle(TableHandle):
         cosmos_db: CosmosBaseServer,
         rows_per_partition: int = None,
         schema: StructType = None,
+        *,
+        partition_key: str = None,
     ):
         self._name = name
         self._cosmos_db = cosmos_db
         self._rows_per_partition = rows_per_partition
         self._schema = schema
+        # "pk" is the dafault partition key in all cosmos uses that I have seen.
+        self._partition_key = partition_key or "pk"
+        self._id_key = "id"
 
     def read(self) -> DataFrame:
         return self._cosmos_db.read_table_by_name(
@@ -70,7 +75,10 @@ class CosmosHandle(TableHandle):
         raise NotImplementedError("Method not supported in Cosmos")
 
     def upsert(self, df: DataFrame, join_cols: List[str]) -> Union[DataFrame, None]:
-        raise NotImplementedError("Method not supported in Cosmos")
+        if set(join_cols) != set([self._id_key, self._partition_key]):
+            raise NotImplementedError("Generalized upsert not supported in Cosmos")
+        # upserting by id and pk is the same as appending for cosmos
+        return self.append(df)
 
     def get_tablename(self) -> str:
         return self._name

--- a/tests/cluster/cosmos/test_cosmos.py
+++ b/tests/cluster/cosmos/test_cosmos.py
@@ -72,7 +72,9 @@ class CosmosTests(unittest.TestCase):
         # drop and recreate the container
         # we should end up with only the new rows.
         ch.recreate()
-        ch.append(new_df)
+        # use upsert this time to test it
+        ch.upsert(new_df, join_cols=["id", "pk"])
+
         self.assertEqual(ch.read().count(), 2)
 
     @classmethod


### PR DESCRIPTION
Cosmos handles do not allow upsert today.

Actually, writing and upserting to cosmos is the same thing if the upsert columns are the key columns that cosmos uses.
This PR introduces a change that allows the use of upsert on cosmos handles.

This will not break existing implementations unless they relied on the fact that cosmos handles raise this exception, which would be strange.