### PR TITLE
feat: eventhub handle using kafka

### DIFF
--- a/docs/eventhub/README.md
+++ b/docs/eventhub/README.md
@@ -1,0 +1,110 @@
+# KafkaEventhubHandle
+The `KafkaEventhubHandle` class provides convenient methods for interacting with Azure Event Hubs using the Kafka-compatible endpoint in Apache Spark applications. It allows for reading from and writing to Event Hubs via the Kafka format.
+
+## Usage
+
+### Reading from Event Hubs (via Kafka)
+
+To read data from an Event Hub, use the `read` method:
+
+The written schema is:
+
+
+Using the orchestrator without adding any filtering `.filter_with` the output schema is the following:
+
+| **Column Name**   | **Data type** | **Explanation**                                                                                                    |
+|-------------------|---------------|--------------------------------------------------------------------------------------------------------------------|
+| EventhubRowId            | Long          | An ID generated to give a unique id for row in the bronze table. Calculated based on sha2 hashing the *Body* and *EnqueuedTimestamp*. _NB: There is a possibility for non-uniqueness._ |
+| BodyId            | Long          | An ID generated to give a unique id for each unique *Body* message. Calculated based on sha2 hashing the *Body*. Can be used for identify rows with same *Body*. |
+| EnqueuedTimestamp | Timestamp     | The enqueueded time of the eventhub row. This is a transformation of the [EnqueuedTime](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.eventhubs.eventdata.enqueuedtime?view=azure-dotnet), which is the date and time, in UTC, of when the event was enqueued in the Event Hub partition.                                                                         |
+| StreamingTime     | Timestamp     | A timestamp added in the moment the orchestrator processed eventhub data.                                          |
+|[SequenceNumber](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.eventhubs.eventdata.sequencenumber?view=azure-dotnet)| Long | Gets the logical sequence number of the event within the partition stream of the Event Hub.|
+|[Offset](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.eventhubs.eventdata.offset?view=azure-dotnet)| String | Gets the offset of the data relative to the Event Hub partition stream. The offset is a marker or identifier for an event within the Event Hubs stream. The identifier is unique within a partition of the Event Hubs stream.|
+|[SystemProperties](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.eventhubs.eventdata.systemproperties?view=azure-dotnet)|String | The set of free-form event properties which were provided by the Event Hubs service to pass metadata associated with the event or associated Event Hubs operation.|
+|[Properties](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.eventhubs.eventdata.properties?view=azure-dotnet)| String | The set of free-form properties which may be used for associating metadata with the event that is meaningful within the application context.|
+| Body              | String        | The eventhub body casted as a string - for readability and searchability. Transformed version of the [binary body](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.eventhubs.eventdata.eventbody?view=azure-dotnet).                                          |
+
+|
+
+```python
+from spetlr.eh import EventhubHandle
+
+# Initialize KafkaEventhubHandle instance
+eh = EventhubHandle(
+    consumer_group="consumer_group_name",
+    namespace="your_namespace",
+    eventhub="your_eventhub_name",
+    accessKeyName="your_key_name",
+    accessKey="your_key",
+)
+
+# Read data from Event Hub
+df = eh.read()
+```
+
+### Writing to Event Hubs
+To write data to an Event Hub, use the `append` method:
+
+```python
+from spetlr.eh import EventhubHandle
+
+# Initialize KafkaEventhubHandle instance
+eh = EventhubHandle(
+    consumer_group="consumer_group_name",
+    namespace="your_namespace",
+    eventhub="your_eventhub_name",
+    accessKeyName="your_key_name",
+    accessKey="your_key",
+)
+
+# Assuming 'df' is your DataFrame containing data to be written
+eh.append(df)
+```
+
+### Streaming with KafkaEventhubHandle
+
+You can use `KafkaEventhubHandle` in streaming operations. Here's an example of streaming extraction and loading using `Orchestrator`, `StreamExtractor`, and `StreamLoader`:
+
+```python
+from spetlr.etl import Orchestrator
+from spetlr.etl.extractors.stream_extractor import StreamExtractor
+from spetlr.etl.loaders.stream_loader import StreamLoader
+from spetlr.etl.loaders import SimpleLoader
+from spetlr.delta import DeltaHandle
+from spetlr.configurator import Configurator
+from spetlr.eh import EventhubHandle
+
+# Initialize KafkaEventhubHandle instance for source
+eh_source = EventhubHandle(...)
+
+# Initialize DeltaHandle instance for target
+dh_target = DeltaHandle(...)
+
+# Build and execute the orchestration pipeline
+(
+    Orchestrator()
+        .extract_from(
+            StreamExtractor(
+                eh_source,
+                dataset_key="MyTbl",
+            )
+        )
+        .load_into(
+            StreamLoader(
+                loader=SimpleLoader(handle=dh_target, mode="append"),
+                await_termination=True,
+                checkpoint_path=Configurator().get("MyTblMirror", "checkpoint_path"),
+            )
+        )
+        .execute()
+)
+```
+
+This pipeline extracts data from the Event Hub using `StreamExtractor` and `KafkaEventhubHandle`, loads it into the specified Delta table using `StreamLoader`, and executes the orchestration.
+
+### Other Methods
+* `from_tc`: Instantiates the handle using parameters defined in the configuration (via `Configurator`).
+* `set_options_dict`: Sets Kafka options for the Event Hub connection.
+* `get_options_dict`: Retrieves the Kafka options dictionary.
+* `get_schema`: Retrieves the schema associated with the Event Hub data.
+* `set_schema`: Sets the schema for the Event Hub data.

--- a/src/spetlr/eh/__init__.py
+++ b/src/spetlr/eh/__init__.py
@@ -1,3 +1,4 @@
+from .eventhub_handle import EventhubHandle  # noqa: F401
 from .EventHubCapture import EventHubCapture  # noqa: F401
 from .EventHubCaptureExtractor import EventHubCaptureExtractor  # noqa: F401
 from .EventHubJsonPublisher import EventHubJsonPublisher  # noqa: F401

--- a/src/spetlr/eh/eventhub_handle.py
+++ b/src/spetlr/eh/eventhub_handle.py
@@ -1,0 +1,304 @@
+import datetime
+from typing import Dict
+from urllib.parse import urlparse
+
+import pyspark.sql.functions as f
+from pyspark.sql import DataFrame
+from pyspark.sql.types import StructType
+
+from spetlr import Configurator
+from spetlr.exceptions import (
+    InvalidEventhubConnectionString,
+    InvalidEventhubHandleParameters,
+    InvalidEventhubWriteSchema,
+)
+from spetlr.schema_manager import SchemaManager
+from spetlr.spark import Spark
+from spetlr.tables import TableHandle
+
+
+class EventhubHandle(TableHandle):
+    """
+    Kafka-compatible Event Hub handle for reading and writing data in Apache Spark.
+
+    This class provides functionality to interact with Azure Event Hubs through
+    its Kafka-compatible endpoint using PySpark's Kafka source and sink. It allows
+    structured and streaming reads, as well as structured writes, while supporting
+    optional schema parsing of the message payload.
+
+    Attributes:
+        kafkaConfigs (dict): Kafka consumer/producer configuration.
+        _schema (StructType): Optional schema used to parse JSON-encoded values.
+        bootstrap_servers (str): Kafka-compatible Event Hub bootstrap server URL.
+        topic (str): Event Hub name used as the Kafka topic.
+
+    Methods:
+        from_tc(id):
+           Create an instance from configuration using the Configurator.
+        read():
+           Perform a batch read from the Event Hub.
+        read_stream():
+           Perform a streaming read from the Event Hub.
+        write_or_append(df, mode, mergeSchema, overwriteSchema):
+           Write data to the Event Hub.
+        overwrite(df, mergeSchema, overwriteSchema):
+           Alias for write_or_append in overwrite mode.
+        append(df, mergeSchema):
+           Alias for write_or_append in append mode.
+        set_options_dict(options):
+           Set the Kafka options dictionary.
+        get_options_dict():
+           Retrieve the Kafka options dictionary.
+        get_schema():
+           Retrieve the configured schema.
+        set_schema(schema):
+           Set a new schema for parsing incoming data.
+    """
+
+    def __init__(
+        self,
+        namespace: str = None,
+        eventhub: str = None,
+        consumer_group: str = None,
+        connection_str: str = None,
+        accessKeyName: str = None,
+        accessKey: str = None,
+        maxEventsPerTrigger: int = None,
+        kafkaConfigs: dict = None,
+        schema: StructType = None,
+    ):
+
+        if connection_str is None:
+            if (
+                namespace is None
+                or eventhub is None
+                or accessKeyName is None
+                or accessKey is None
+            ):
+                raise InvalidEventhubHandleParameters(
+                    "Either connectionString or "
+                    "(namespace, eventhub, accessKeyName and accessKey) "
+                    "have to be supplied"
+                )
+
+            self.connectionString = (
+                f"Endpoint=sb://{namespace}.servicebus.windows.net/{eventhub};"
+                f"EntityPath={eventhub};SharedAccessKeyName={accessKeyName};"
+                f"SharedAccessKey={accessKey}"
+            )
+        else:
+            self.connectionString = connection_str
+
+            # Split up connection string to retrieve relevant info
+
+            try:
+                cstring_parts = {
+                    p.split("=")[0]: p.split("=")[1]
+                    for p in self.connectionString.split(";")
+                }
+            except IndexError:
+                raise InvalidEventhubConnectionString(
+                    "Invalid eventhub connection string!"
+                )
+
+        # The logic trust the explicit setted namespace
+        # over the connectionstring
+        if namespace is None:
+
+            self.bootstrap_servers = (
+                urlparse(cstring_parts["Endpoint"]).netloc + ":9093"
+            )
+        else:
+            self.bootstrap_servers = f"{namespace}.servicebus.windows.net:9093"
+
+        self.topic = eventhub or cstring_parts["EntityPath"]
+
+        self._schema = schema
+
+        self.kafkaConfigs = {
+            "kafka.bootstrap.servers": self.bootstrap_servers,
+            "subscribe": self.topic,
+            "kafka.security.protocol": "SASL_SSL",
+            "kafka.sasl.mechanism": "PLAIN",
+            # ==== sasl.jass.config start ====
+            "kafka.sasl.jaas.config": f"kafkashaded.org.apache.kafka"
+            f".common.security.plain"
+            f".PlainLoginModule required "
+            f'username="$ConnectionString" '
+            f'password="{self.connectionString}";',
+            # ==== sasl.jass.config end ====
+        }
+
+        if maxEventsPerTrigger is not None:
+            self.kafkaConfigs["maxOffsetsPerTrigger"] = str(maxEventsPerTrigger)
+
+        if kafkaConfigs:
+            self.kafkaConfigs.update(kafkaConfigs)
+
+        if consumer_group:
+            self.kafkaConfigs["kafka.group.id"] = consumer_group
+
+    @classmethod
+    def from_tc(
+        cls,
+        id: str,
+        connection_str: str = None,
+        accessKey: str = None,
+    ) -> "EventhubHandle":
+        tc = Configurator()
+
+        _raw_maxEventsPerTrigger = tc.get(id, "eh_maxEventsPerTrigger", None)
+        maxEventsPerTrigger = (
+            int(_raw_maxEventsPerTrigger)
+            if _raw_maxEventsPerTrigger is not None
+            else None
+        )
+
+        return cls(
+            namespace=tc.get(id, "eh_namespace", None),
+            eventhub=tc.get(id, "eh_eventhub", None),
+            consumer_group=tc.get(id, "eh_consumer_group", None),
+            connection_str=connection_str or tc.get(id, "eh_connection_str", None),
+            accessKeyName=tc.get(id, "eh_accessKeyName", None),
+            accessKey=accessKey
+            or tc.get(id, "eh_accessKey", None),  # Not recommended to set in .yml
+            maxEventsPerTrigger=maxEventsPerTrigger,
+            kafkaConfigs=tc.get(id, "eh_eventhubConfigs", None),
+            schema=SchemaManager().get_schema(id, None),
+        )
+
+    def read(self) -> DataFrame:
+        df = (
+            Spark.get()
+            .read.format("kafka")
+            .option("startingOffsets", "earliest")
+            .options(**self.kafkaConfigs)
+            .load()
+        )
+
+        df = self._convert_kafka_schema_to_eventhub_schema(df)
+
+        if self._schema:
+            df = df.withColumn("Body", f.from_json("Body", self._schema))
+        else:
+            print(
+                "No schema was detected in the EventhubHandle. "
+                "Body is formatted as string..."
+            )
+        return df
+
+    def read_stream(self):
+        df = (
+            Spark.get()
+            .readStream.format("kafka")
+            .option("startingOffsets", "earliest")
+            .options(**self.kafkaConfigs)
+            .load()
+        )
+
+        df = self._convert_kafka_schema_to_eventhub_schema(df)
+
+        if self._schema:
+            df = df.withColumn("Body", f.from_json("Body", self._schema))
+        else:
+            print(
+                "No schema was detected in the EventhubHandle. "
+                "Body is formatted as string..."
+            )
+        return df
+
+    def write_or_append(
+        self,
+        df: DataFrame,
+        mode: str,
+        mergeSchema: bool = None,
+        overwriteSchema: bool = None,
+    ) -> None:
+        """
+        It is up to the user of the EventhubHandle class
+        to provide a schema, that matches the write semantics
+
+        Link: https://spark.apache.org/docs/
+                latest/structured-streaming-kafka-integration.html#writing-data-to-kafka
+
+        """
+
+        assert mode in {"append", "overwrite"}
+
+        if mode == "overwrite":
+            print("Kafka does not support overwrite mode. Switching to append.")
+            mode = "append"
+
+        self._check_write_dataframe(df)
+
+        writer = (
+            df.write.format("kafka")
+            .options(**self.kafkaConfigs)
+            .mode(mode)
+            .option("topic", self.topic)
+        )
+        return writer.save()
+
+    def overwrite(
+        self, df: DataFrame, mergeSchema: bool = None, overwriteSchema: bool = None
+    ) -> None:
+        return self.write_or_append(df, "overwrite")
+
+    def append(self, df: DataFrame, mergeSchema: bool = None) -> None:
+        return self.write_or_append(df, "append")
+
+    def set_options_dict(self, options: Dict[str, str]):
+        self.kafkaConfigs = options
+
+    def get_options_dict(self) -> Dict[str, str]:
+        return self.kafkaConfigs
+
+    def get_schema(self) -> StructType:
+        return self._schema
+
+    def set_schema(self, schema: StructType) -> None:
+        self._schema = schema
+
+    @staticmethod
+    def _check_write_dataframe(df: DataFrame) -> None:
+        _lower_cols = [col.lower() for col in df.columns]
+
+        if "value" not in _lower_cols:
+            raise InvalidEventhubWriteSchema("You must provide at least a Kafka value!")
+
+    @staticmethod
+    def _convert_kafka_schema_to_eventhub_schema(df: DataFrame) -> DataFrame:
+
+        # Generate Unique id for the eventhub rows
+        df = df.withColumn(
+            "EventhubRowId",
+            f.xxhash64(
+                f.sha2(f.col("value").cast("string"), 256),
+                f.sha2(f.col("timestamp").cast("string"), 256),
+            ).cast("long"),
+        )
+
+        # Generate id for the eventhub rows using hashed body
+        # Can be used for identify rows with same body
+        df = df.withColumn(
+            "BodyId",
+            f.xxhash64(f.lit("0"), f.col("value").cast("string")).cast("long"),
+        )
+
+        # Add streaming time
+        streaming_time = datetime.datetime.now(datetime.timezone.utc).replace(
+            microsecond=0
+        )
+
+        return df.select(
+            f.col("EventhubRowId").cast("long").alias("EventhubRowId"),
+            f.col("BodyId").cast("long").alias("BodyId"),
+            f.col("offset").cast("bigint").alias("SequenceNumber"),
+            f.col("partition").cast("int").alias("PartitionNumber"),
+            f.col("timestamp").cast("DATE").alias("EnqueuedDate"),
+            f.col("timestamp").cast("TIMESTAMP").alias("EnqueuedTime"),
+            f.lit(streaming_time).alias("StreamingTime"),
+            f.lit("{}").alias("Properties"),
+            f.lit("{}").alias("SystemProperties"),
+            f.col("value").cast("string").alias("Body"),
+        )

--- a/src/spetlr/etl/transformers/__init__.py
+++ b/src/spetlr/etl/transformers/__init__.py
@@ -25,6 +25,9 @@ from spetlr.etl.transformers.selectColumnsTransformer import (  # noqa: F401
 from spetlr.etl.transformers.simple_dataframe_filter_transformer import (  # noqa: F401
     DataFrameFilterTransformer,
 )
+from spetlr.etl.transformers.simple_eh_handle_write_transformer import (  # noqa: F401
+    SimpleEventhubHandleTransformer,
+)
 from spetlr.etl.transformers.simple_sql_transformer import (  # noqa: F401
     SimpleSqlServerTransformer,
 )

--- a/src/spetlr/etl/transformers/simple_eh_handle_write_transformer.py
+++ b/src/spetlr/etl/transformers/simple_eh_handle_write_transformer.py
@@ -1,0 +1,19 @@
+import pyspark.sql.functions as f
+from pyspark.sql import DataFrame
+
+from spetlr.etl import Transformer
+
+
+class SimpleEventhubHandleTransformer(Transformer):
+    """
+    This class is a simple, and naive, way of taking your
+    dataframe - and save it in a value column ready for
+    writing using the EventhubHandle class
+    """
+
+    def process(self, df: DataFrame) -> DataFrame:
+        return (
+            df.withColumn("value", f.struct(df.columns))
+            .withColumn("value", f.to_json("value"))
+            .selectExpr("CAST(value AS STRING)")
+        )

--- a/src/spetlr/exceptions/__init__.py
+++ b/src/spetlr/exceptions/__init__.py
@@ -91,3 +91,15 @@ class AmbiguousColumnsAfterCleaning(SpetlrException):
 class SchemasNotEqualException(SpetlrException):
     value = "Column names after cleaning are ambiguous!"
     pass
+
+
+class InvalidEventhubHandleParameters(SpetlrException):
+    pass
+
+
+class InvalidEventhubConnectionString(SpetlrException):
+    pass
+
+
+class InvalidEventhubWriteSchema(SpetlrException):
+    pass

--- a/tests/cluster/eh/test_eh_saving.py
+++ b/tests/cluster/eh/test_eh_saving.py
@@ -1,7 +1,9 @@
 import time
 import unittest
+import uuid as _uuid
 from datetime import datetime, timedelta, timezone
 
+import pyspark.sql.functions as f
 from pyspark.sql import DataFrame
 from spetlrtools.time import dt_utc
 
@@ -21,11 +23,14 @@ class EventHubsTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         Configurator().clear_all_configurations()
+        cls.UUID_test = _uuid.uuid4().hex
 
     def test_01_publish_and_read(self):
         eh = SpetlrEh()
 
-        df = Spark.get().createDataFrame([(1, "a"), (2, "b")], "id int, name string")
+        df = Spark.get().createDataFrame(
+            [(1, self.UUID_test), (2, self.UUID_test)], "id int, name string"
+        )
         publisher = EventHubJsonPublisher(eh)
         publisher.save(df)
 
@@ -46,14 +51,14 @@ class EventHubsTests(unittest.TestCase):
         )
         eh = EventHubCaptureExtractor.from_tc("SpetlrEh")
         df = eh.read()
-        self.assertTrue(df.count(), 2)
+        self.assertEqual(self._count_uuid_rows(df), 2)
 
         df = eh.read(
             (datetime.now() - timedelta(hours=24)).replace(
                 hour=0, minute=0, second=0, microsecond=0
             )
         )
-        self.assertTrue(df.count(), 2)
+        self.assertEqual(self._count_uuid_rows(df), 2)
 
         df = eh.read().select("EnqueuedTimestamp")
         self.assertEqual(
@@ -95,8 +100,12 @@ class EventHubsTests(unittest.TestCase):
 
         df = DeltaHandle.from_tc("CpTblYMD").read().select("id", "name")
 
+        # FILTER ONLY ROWS WITH UUID_TEST
+        df = df.filter(f.col("name").like("%" + self.UUID_test + "%"))
+
         rows = {tuple(row) for row in df.collect()}
-        self.assertEqual({(1, "a"), (2, "b")}, rows)
+
+        self.assertEqual({(1, self.UUID_test), (2, self.UUID_test)}, rows)
 
         # Part 2, pdate partitioned.
 
@@ -123,6 +132,21 @@ class EventHubsTests(unittest.TestCase):
         eh_orch2.execute()
 
         df2 = DeltaHandle.from_tc("CpTblDate").read().select("id", "name")
+        # FILTER ONLY ROWS WITH UUID_TEST
+        df2 = df2.filter(f.col("name").like("%" + self.UUID_test + "%"))
 
         rows = {tuple(row) for row in df2.collect()}
-        self.assertEqual({(2, "b")}, rows)
+        self.assertEqual({(2, self.UUID_test)}, rows)
+
+    def _count_uuid_rows(self, df: DataFrame) -> int:
+        """
+        This is a helper test function
+        that checks the number of rows with this test UUID.
+
+        Since multiple tests can add data to the eventhub
+        at the same time - the UUID ensures that we only work within
+        the scope of this test.
+        """
+        df = df.select(f.col("body").cast("string").alias("string_body"))
+
+        return df.filter(f.col("string_body").like("%" + self.UUID_test + "%")).count()

--- a/tests/cluster/eh/test_eventhub_handle.py
+++ b/tests/cluster/eh/test_eventhub_handle.py
@@ -1,0 +1,211 @@
+import time
+import unittest
+import uuid as _uuid
+from datetime import datetime, timezone
+
+import pyspark.sql.functions as f
+from pyspark.sql import DataFrame
+from spetlrtools.time import dt_utc
+
+from spetlr.configurator import Configurator
+from spetlr.delta import DbHandle, DeltaHandle
+from spetlr.eh import EventhubHandle
+from spetlr.etl import Orchestrator, Transformer
+from spetlr.etl.extractors.stream_extractor import StreamExtractor
+from spetlr.etl.loaders import SimpleLoader
+from spetlr.etl.loaders.stream_loader import StreamLoader
+from spetlr.etl.transformers.simple_eh_handle_write_transformer import (
+    SimpleEventhubHandleTransformer,
+)
+from spetlr.functions import init_dbutils
+from spetlr.spark import Spark
+from tests.cluster.values import resourceName
+
+
+class EventHubHandleTests(unittest.TestCase):
+    connection_str = None
+    tc = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tc = Configurator()
+        cls.tc.clear_all_configurations()
+
+        cls.tc.set_debug()
+
+        cls.connection_str = init_dbutils().secrets.get("secrets", "EventHubConnection")
+
+        # eventhub = "spetlreh"
+        consumer_group = "$Default"
+
+        cls.tc.register(
+            "SpetlrEh",
+            {
+                "path": f"/mnt/{resourceName()}/silver/{resourceName()}/spetlreh",
+                "format": "avro",
+                "partitioning": "ymd",
+                # "eh_eventhub": eventhub,
+                # "eh_namespace": resourceName(),
+                "eh_consumer_group": consumer_group,
+            },
+        )
+
+        cls.tc.register(
+            "MyDb", {"name": "TestDb{ID}", "path": "/mnt/spetlr/silver/testdb{ID}"}
+        )
+
+        cls.tc.register(
+            "MyTbl",
+            {
+                "name": "TestDb{ID}.TestTbl",
+                "path": "/mnt/spetlr/silver/testdb{ID}/testtbl",
+                "format": "delta",
+                "checkpoint_path": "/mnt/spetlr/silver/testdb{ID}/_checkpoint_path_tbl",
+                "query_name": "testquerytbl{ID}",
+            },
+        )
+
+        cls.tc.register(
+            "MyTbl2",
+            {
+                "name": "TestDb{ID}.TestTbl2",
+                "path": "/mnt/spetlr/silver/testdb{ID}/testtbl2",
+                "format": "delta",
+                "checkpoint_path": "/mnt/spetlr/silver/testdb{ID}/"
+                "_checkpoint_path_tbl2",
+                "query_name": "testquerytbl2{ID}",
+            },
+        )
+
+        cls.tc.register(
+            "EhWrite",
+            {
+                "checkpoint_path": "/mnt/spetlr/silver/ehwrite{ID}/"
+                "_checkpoint_path_tbl",
+            },
+        )
+
+        cls.UUID_test1 = _uuid.uuid4().hex
+
+        DbHandle.from_tc("MyDb").create()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        DbHandle.from_tc("MyDb").drop_cascade()
+
+    def test_01_publish_and_read(self):
+        """
+        Test a simple write to the eventhub
+
+        """
+        eh = EventhubHandle.from_tc("SpetlrEh", connection_str=self.connection_str)
+
+        df = Spark.get().createDataFrame(
+            [(1, self.UUID_test1), (2, self.UUID_test1)], "id int, name string"
+        )
+
+        df = SimpleEventhubHandleTransformer().process(df)
+
+        eh.overwrite(df)
+
+        time.sleep(100)
+
+        df = eh.read()
+
+        self.assertGreaterEqual(self._count_uuid_rows(df), 2)
+
+        df = eh.read().select("enqueuedTime")
+        self.assertEqual(
+            df.schema.fields[0].dataType.typeName().upper(),
+            "TIMESTAMP",
+        )
+        row_written: datetime = df.take(1)[0][0]
+        self.assertLess(
+            abs((row_written.astimezone(timezone.utc) - dt_utc()).total_seconds()), 1000
+        )
+
+    def test_02_test_streaming_read(self):
+        """
+        test_01 should have been runned first,
+        this ensures data for the eventhub.
+
+        This test then streams from the eventhub into a delta table.
+
+        """
+        eh_source = EventhubHandle.from_tc(
+            "SpetlrEh", connection_str=self.connection_str
+        )
+        dh_target = DeltaHandle.from_tc("MyTbl")
+
+        (
+            Orchestrator()
+            .extract_from(
+                StreamExtractor(
+                    eh_source,
+                    dataset_key="SpetlrEh",
+                )
+            )
+            .load_into(
+                StreamLoader(
+                    loader=SimpleLoader(handle=dh_target, mode="append"),
+                    await_termination=True,
+                    checkpoint_path=Configurator().get("MyTbl", "checkpoint_path"),
+                )
+            )
+            .execute()
+        )
+
+        # Test that some of the data from the eventhub has been written
+        self.assertEqual(self._count_uuid_rows(dh_target.read()), 2)
+
+    def test_03_test_streaming_write(self):
+        """
+        test_02 should have been runned first.
+        This ensures data for the eventhub.
+
+        This test then streams from the delta table back to the eventhub.
+        """
+        eh_source = EventhubHandle.from_tc("SpetlrEh", self.connection_str)
+        dh_target = DeltaHandle.from_tc("MyTbl2")
+
+        # Add two rows to the delta table
+        df = Spark.get().createDataFrame(
+            [(1, self.UUID_test1), (2, self.UUID_test1)], "id int, name string"
+        )
+        dh_target.overwrite(df)
+        self.assertGreaterEqual(dh_target.read().count(), 2)
+
+        (
+            Orchestrator()
+            .extract_from(
+                StreamExtractor(
+                    dh_target,
+                )
+            )
+            .transform_with(SimpleEventhubHandleTransformer())
+            .load_into(
+                StreamLoader(
+                    loader=SimpleLoader(handle=eh_source, mode="append"),
+                    await_termination=True,
+                    checkpoint_path=Configurator().get("EhWrite", "checkpoint_path"),
+                )
+            )
+            .execute()
+        )
+
+        # There should now be 4 rows in the eventhub with the unique id
+        time.sleep(100)
+        self.assertGreaterEqual(self._count_uuid_rows(eh_source.read()), 4)
+
+    def _count_uuid_rows(self, df: DataFrame) -> int:
+        """
+        This is a helper test function
+        that checks the number of rows with this test UUID.
+
+        Since multiple tests can add data to the eventhub
+        at the same time - the UUID ensures that we only work within
+        the scope of this test.
+        """
+        df = df.select(f.col("Body").cast("string").alias("string_body"))
+
+        return df.filter(f.col("string_body").like("%" + self.UUID_test1 + "%")).count()

--- a/tests/local/eh/test_eventhub_handle.py
+++ b/tests/local/eh/test_eventhub_handle.py
@@ -1,0 +1,602 @@
+import json
+from datetime import timezone
+from unittest.mock import patch
+
+from pyspark.sql.types import (
+    BooleanType,
+    DateType,
+    IntegerType,
+    LongType,
+    Row,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
+from spetlrtools.testing import DataframeTestCase
+from spetlrtools.time import dt_utc
+
+from spetlr import Configurator
+from spetlr.eh.eventhub_handle import EventhubHandle
+from spetlr.exceptions import (
+    InvalidEventhubConnectionString,
+    InvalidEventhubHandleParameters,
+    InvalidEventhubWriteSchema,
+)
+from spetlr.schema_manager import SchemaManager
+from spetlr.spark import Spark
+
+
+class KafkaEventhubHandleTest(DataframeTestCase):
+
+    _kafka_schema_cols = [
+        "key",
+        "value",
+        "topic",
+        "partition",
+        "offset",
+        "timestamp",
+        "timestampType",
+    ]
+
+    _test_cn_string = (
+        "Endpoint=sb://NamespaceName.servicebus.windows.net/;"
+        "SharedAccessKeyName=KeyName;SharedAccessKey=KeyValue"
+    )
+
+    def test_create_with_connectionString(self):
+        eh = EventhubHandle(
+            connection_str=self._test_cn_string,
+            consumer_group="testConsumerGroup",
+            eventhub="hey",
+            namespace="there",
+            maxEventsPerTrigger=100000,
+        )
+
+        self.assertEqual(eh.connectionString, self._test_cn_string)
+
+    def test_create_without_connectionString(self):
+        eh = EventhubHandle(
+            namespace="testNamespace",
+            eventhub="testEventhub",
+            accessKeyName="testAccessKeyName",
+            accessKey="testAccessKey",
+            consumer_group="testConsumerGroup",
+            maxEventsPerTrigger=100000,
+        )
+
+        self.assertEqual(
+            eh.connectionString,
+            "Endpoint=sb://testNamespace.servicebus.windows.net/testEventhub;"
+            "EntityPath=testEventhub;SharedAccessKeyName=testAccessKeyName;"
+            "SharedAccessKey=testAccessKey",
+        )
+
+    def test_raise_create_exeption(self):
+        with self.assertRaises(InvalidEventhubHandleParameters):
+            EventhubHandle(
+                connection_str=None,
+                namespace=None,
+                eventhub="testEventhub",
+                accessKeyName="testAccessKeyName",
+                accessKey="testAccessKey",
+                consumer_group="testConsumerGroup",
+                maxEventsPerTrigger=100000,
+            )
+
+        with self.assertRaises(InvalidEventhubHandleParameters):
+            EventhubHandle(
+                connection_str=None,
+                namespace="testNamespace",
+                eventhub=None,
+                accessKeyName="testAccessKeyName",
+                accessKey="testAccessKey",
+                consumer_group="testConsumerGroup",
+                maxEventsPerTrigger=100000,
+            )
+
+        with self.assertRaises(InvalidEventhubHandleParameters):
+            EventhubHandle(
+                connection_str=None,
+                namespace="testNamespace",
+                eventhub="testEventhub",
+                accessKeyName=None,
+                accessKey="testAccessKey",
+                consumer_group="testConsumerGroup",
+                maxEventsPerTrigger=100000,
+            )
+
+        with self.assertRaises(InvalidEventhubHandleParameters):
+            EventhubHandle(
+                connection_str=None,
+                namespace="testNamespace",
+                eventhub="testEventhub",
+                accessKeyName="testAccessKeyName",
+                accessKey=None,
+                consumer_group="testConsumerGroup",
+                maxEventsPerTrigger=100000,
+            )
+
+    def test_kafka_config_construction(self):
+        handle = EventhubHandle(
+            consumer_group="testGroup",
+            namespace="testNamespace",
+            eventhub="testEventhub",
+            accessKeyName="testKeyName",
+            accessKey="testKey",
+            maxEventsPerTrigger=50000,
+        )
+
+        self.assertEqual(
+            handle.kafkaConfigs["kafka.bootstrap.servers"],
+            "testNamespace.servicebus.windows.net:9093",
+        )
+        self.assertEqual(handle.kafkaConfigs["subscribe"], "testEventhub")
+        self.assertEqual(handle.kafkaConfigs["kafka.group.id"], "testGroup")
+        self.assertEqual(handle.kafkaConfigs["maxOffsetsPerTrigger"], "50000")
+
+    def test_from_tc(self):
+        # Initialize the Configurator to manage test configurations
+        tc = Configurator()
+        # Clear any existing configurations to ensure a clean test environment
+        tc.clear_all_configurations()
+        # Enable debug mode
+        tc.set_debug()
+
+        # Define test values for event hub and consumer group
+        eventhub = "spetlreh"
+        consumer_group = "$Default"
+
+        # Register a test configuration with various parameters
+        tc.register(
+            "SpetlrEh",
+            {
+                "path": "/mnt/test/silver/spetlreh",
+                "format": "avro",
+                "partitioning": "ymd",
+                "eh_eventhub": eventhub,
+                "eh_consumer_group": consumer_group,
+                "eh_connection_str": self._test_cn_string,
+                "eh_namespace": "testNamespace",
+                "eh_accessKeyName": "testAccessKeyName",
+                "eh_accessKey": "testAccessKey",
+                "eh_maxEventsPerTrigger": "500000",
+                "schema": "EhSchema",
+            },
+        )
+
+        # Define an expected schema to be used in assertions later
+        _expected_schema = StructType(
+            [
+                StructField("col_1", StringType(), True),
+                StructField("col_2", IntegerType(), True),
+                StructField("col_3", BooleanType(), True),
+                StructField("col_4", TimestampType(), True),
+            ]
+        )
+
+        # Register the expected schema with the SchemaManager
+        SchemaManager().register_schema("EhSchema", _expected_schema)
+
+        # Patch the 'read' method of EventhubHandle to not perform its actual function
+        with patch.object(EventhubHandle, "read", return_value=None):
+            # Use the class method 'from_tc' to create an instance of
+            # EventhubHandle with the test configuration
+            eh = EventhubHandle.from_tc("SpetlrEh")
+            # Call the patched 'read' method
+
+            eh.read()
+
+            # Define the expected dictionary to verify eventhub configuration
+            _expected_dict = {
+                "kafka.bootstrap.servers": "testNamespace.servicebus.windows.net:9093",
+                "subscribe": "spetlreh",
+                "kafka.security.protocol": "SASL_SSL",
+                "kafka.sasl.mechanism": "PLAIN",
+                "kafka.sasl.jaas.config": "kafkashaded.org.apache.kafka.common.security"
+                ".plain.PlainLoginModule "
+                'required username="$ConnectionString" '
+                f'password="{self._test_cn_string}";',
+                "maxOffsetsPerTrigger": "500000",
+                "kafka.group.id": "$Default",
+            }
+            # Assert that the connectionString is as expected
+            self.assertEqual(eh.connectionString, self._test_cn_string)
+            # Assert that the schema matches the expected schema
+            self.assertEqual(eh._schema, _expected_schema)
+            # Assert that the options dictionary matches the expected values
+            print(eh.get_options_dict())
+            self.assertEqual(eh.get_options_dict(), _expected_dict)
+
+    def test_from_tc_with_explicit_connection_str(self):
+        """
+        Test the EventhubHandle.from_tc method with an explicit connection string.
+        """
+        # Initialize the Configurator to manage test configurations
+        tc = Configurator()
+        tc.clear_all_configurations()
+        tc.set_debug()
+
+        # Register a minimal configuration for testing
+        tc.register(
+            "SpetlrEh",
+            {
+                "eh_connection_str": "explicitConnectionString",
+                "eh_consumer_group": "$Default",
+                "eh_eventhub": "testEventhub",
+                "eh_namespace": "testNamespace",
+                "eh_accessKeyName": "testAccessKeyName",
+                "eh_accessKey": "testAccessKey",
+            },
+        )
+
+        # Define the explicit connection string to be used
+        explicit_connection_str = self._test_cn_string
+
+        # Patch the 'read' method of EventhubHandle to not perform its actual function
+        with patch.object(EventhubHandle, "read", return_value=None):
+            # Use the class method 'from_tc' to create an instance of EventhubHandle
+            # with the test configuration, but override the connection string
+            eh = EventhubHandle.from_tc(
+                id="SpetlrEh", connection_str=explicit_connection_str
+            )
+            # Call the patched 'read' method
+            eh.read()
+
+            # Assert that the connectionString is overridden as expected
+            self.assertEqual(eh.connectionString, explicit_connection_str)
+
+    def test_wrong_from_tc_consumer_group(self):
+        """
+        In this test, the from_tc method misses a consumer group
+        this throws an ValueError
+
+        """
+        tc = Configurator()
+        tc.clear_all_configurations()
+        tc.set_debug()
+
+        eventhub = "spetlreh"
+
+        tc.register(
+            "SpetlrEh",
+            {
+                "path": "/mnt/test/silver/spetlreh",
+                "format": "avro",
+                "partitioning": "ymd",
+                "eh_eventhub": eventhub,
+            },
+        )
+
+        with self.assertRaises(InvalidEventhubHandleParameters):
+            with patch.object(EventhubHandle, "read", return_value=None):
+                EventhubHandle.from_tc("SpetlrEh").read()
+
+    def test_wrong_from_tc_maxtrigger(self):
+        """
+        In this test, the from_tc method have wrong type of max trigger
+
+        """
+        tc = Configurator()
+        tc.clear_all_configurations()
+        tc.set_debug()
+
+        eventhub = "spetlreh"
+        consumer_group = "$Default"
+
+        tc.register(
+            "SpetlrEh",
+            {
+                "path": "/mnt/test/silver/spetlreh",
+                "format": "avro",
+                "partitioning": "ymd",
+                "eh_eventhub": eventhub,
+                "eh_consumer_group": consumer_group,
+                "eh_maxEventsPerTrigger": "hellostring",
+            },
+        )
+        with self.assertRaises(ValueError):
+            with patch.object(EventhubHandle, "read", return_value=None):
+                EventhubHandle.from_tc("SpetlrEh").read()
+
+    def test_from_tc_default_maxtrigger(self):
+        """
+        In this test, the from_tc method have default type of max trigger
+
+        """
+        tc = Configurator()
+        tc.clear_all_configurations()
+        tc.set_debug()
+
+        eventhub = "spetlreh"
+        consumer_group = "$Default"
+
+        tc.register(
+            "SpetlrEh",
+            {
+                "path": "/mnt/test/silver/spetlreh",
+                "format": "avro",
+                "partitioning": "ymd",
+                "eh_eventhub": eventhub,
+                "eh_consumer_group": consumer_group,
+                "eh_namespace": "hey",
+                "eh_accessKeyName": "d",
+            },
+        )
+        with self.assertRaises(KeyError):
+            with patch.object(EventhubHandle, "read", return_value=None):
+                eh = EventhubHandle.from_tc("SpetlrEh", accessKey="2")
+                eh.read()
+                eh.get_options_dict()["maxOffsetsPerTrigger"]
+
+    def test_read_with_schema(self):
+        schema = StructType([StructField("colA", IntegerType(), True)])
+        json_data = json.dumps({"colA": 1}).encode()
+        df = Spark.get().createDataFrame(
+            [
+                (
+                    "some_key",
+                    json_data,
+                    "some_topic",
+                    1,
+                    5888,
+                    dt_utc(2000, 1, 1),
+                    0,
+                )
+            ],
+            self._kafka_schema_cols,
+        )
+
+        handle = EventhubHandle(
+            consumer_group="testGroup",
+            namespace="testNamespace",
+            eventhub="testEventhub",
+            accessKeyName="testKeyName",
+            accessKey="testKey",
+            schema=schema,
+        )
+
+        with patch("pyspark.sql.DataFrameReader.load", return_value=df):
+            resultA = handle.read()
+
+        with patch("pyspark.sql.streaming.DataStreamReader.load", return_value=df):
+            resultB = handle.read_stream()
+
+        _expected_schema = StructType(
+            [
+                # EventhubRowId can be null
+                StructField("EventhubRowId", LongType(), False),
+                # BodyId can be null
+                StructField("BodyId", LongType(), False),
+                StructField("SequenceNumber", LongType(), True),
+                StructField("PartitionNumber", IntegerType(), True),
+                StructField("EnqueuedDate", DateType(), True),
+                StructField("EnqueuedTime", TimestampType(), True),
+                StructField("StreamingTime", TimestampType(), False),
+                StructField("Properties", StringType(), False),
+                StructField("SystemProperties", StringType(), False),
+                StructField("Body", schema, True),
+            ]
+        )
+
+        for result in [resultA, resultB]:
+
+            self.assertEqual(result.schema, _expected_schema)
+            self.assertEqual(
+                result.select("EventhubRowId").collect()[0][0], 3269387136041157559
+            )
+            self.assertEqual(
+                result.select("BodyId").collect()[0][0], -3514496451369984469
+            )
+            self.assertEqual(result.select("SequenceNumber").collect()[0][0], 5888)
+            self.assertEqual(result.select("PartitionNumber").collect()[0][0], 1)
+            self.assertEqual(
+                result.select("EnqueuedDate").collect()[0][0], dt_utc(2000, 1, 1).date()
+            )
+            self.assertEqual(
+                result.select("EnqueuedTime").collect()[0][0].astimezone(timezone.utc),
+                dt_utc(2000, 1, 1),
+            )
+            self.assertEqual(result.select("Properties").collect()[0][0], "{}")
+            self.assertEqual(result.select("SystemProperties").collect()[0][0], "{}")
+            self.assertEqual(result.select("PartitionNumber").collect()[0][0], 1)
+            # Not testing StreamingTime
+            self.assertEqual(result.select("Body").collect()[0][0], Row(colA=1))
+
+    def test_read_without_schema(self):
+        json_data = json.dumps({"colX": 1}).encode()
+        df = Spark.get().createDataFrame(
+            [
+                (
+                    "some_key",
+                    json_data,
+                    "some_topic",
+                    1,
+                    5888,
+                    dt_utc(2000, 1, 1),
+                    0,
+                )
+            ],
+            self._kafka_schema_cols,
+        )
+
+        handle = EventhubHandle(
+            consumer_group="testGroup",
+            namespace="testNamespace",
+            eventhub="testEventhub",
+            accessKeyName="testKeyName",
+            accessKey="testKey",
+        )
+
+        with patch("pyspark.sql.DataFrameReader.load", return_value=df):
+            resultA = handle.read()
+
+        with patch("pyspark.sql.streaming.DataStreamReader.load", return_value=df):
+            resultB = handle.read_stream()
+
+        _expected_schema = StructType(
+            [
+                StructField("EventhubRowId", LongType(), False),
+                StructField("BodyId", LongType(), False),
+                StructField("SequenceNumber", LongType(), True),
+                StructField("PartitionNumber", IntegerType(), True),
+                StructField("EnqueuedDate", DateType(), True),
+                StructField("EnqueuedTime", TimestampType(), True),
+                StructField("StreamingTime", TimestampType(), False),
+                StructField("Properties", StringType(), False),
+                StructField("SystemProperties", StringType(), False),
+                StructField("Body", StringType(), True),
+            ]
+        )
+
+        for result in [resultA, resultB]:
+
+            self.assertEqual(result.schema, _expected_schema)
+            self.assertEqual(
+                result.select("EventhubRowId").collect()[0][0], 1176656857733296004
+            )
+            self.assertEqual(
+                result.select("BodyId").collect()[0][0], 8753335798344916359
+            )
+            self.assertEqual(result.select("SequenceNumber").collect()[0][0], 5888)
+            self.assertEqual(result.select("PartitionNumber").collect()[0][0], 1)
+            self.assertEqual(
+                result.select("EnqueuedDate").collect()[0][0], dt_utc(2000, 1, 1).date()
+            )
+            self.assertEqual(
+                result.select("EnqueuedTime").collect()[0][0].astimezone(timezone.utc),
+                dt_utc(2000, 1, 1),
+            )
+            self.assertEqual(result.select("Properties").collect()[0][0], "{}")
+            self.assertEqual(result.select("SystemProperties").collect()[0][0], "{}")
+            self.assertEqual(result.select("PartitionNumber").collect()[0][0], 1)
+            # Not testing StreamingTime
+            self.assertEqual(result.select("Body").collect()[0][0], '{"colX": 1}')
+
+    def test_valid_write_dataframe_output(self):
+        schema = StructType([StructField("value", StringType())])
+        data = [("value1",), ("value2",)]
+        df_to_write = Spark.get().createDataFrame(data, schema)
+
+        handle = EventhubHandle(  # or EventhubHandle if still testing both
+            consumer_group="testGroup",
+            namespace="testNamespace",
+            eventhub="testEventhub",
+            accessKeyName="testKeyName",
+            accessKey="testKey",
+        )
+
+        handle._check_write_dataframe(df_to_write)
+
+    def test_incorrect_write_schema(self):
+        eh = EventhubHandle(
+            consumer_group="test_group",
+            namespace="test_namespace",
+            eventhub="test_eventhub",
+            accessKeyName="test_key_name",
+            accessKey="test_key",
+        )
+
+        df = Spark.get().createDataFrame(
+            [
+                (
+                    "1",
+                    "2",
+                )
+            ],
+            "key string, another string",
+        )
+        with self.assertRaises(InvalidEventhubWriteSchema):
+            eh.append(df)
+
+    def test_valid_connection_string_parsing(self):
+        eh = EventhubHandle(
+            connection_str=(
+                "Endpoint=sb://testns.servicebus.windows.net/testhub;"
+                "EntityPath=testhub;SharedAccessKeyName=testkey;"
+                "SharedAccessKey=secret"
+            )
+        )
+
+        self.assertEqual(eh.bootstrap_servers, "testns.servicebus.windows.net:9093")
+        self.assertEqual(eh.topic, "testhub")
+
+    def test_invalid_connection_string_raises(self):
+        with self.assertRaises(InvalidEventhubConnectionString):
+            EventhubHandle(connection_str="not a valid conn str")
+
+    def test_minimum_valid_manual_params(self):
+        eh = EventhubHandle(
+            namespace="testns",
+            eventhub="testhub",
+            accessKeyName="testkey",
+            accessKey="secret",
+        )
+
+        self.assertEqual(eh.bootstrap_servers, "testns.servicebus.windows.net:9093")
+        self.assertEqual(eh.topic, "testhub")
+        self.assertIn("SharedAccessKey=secret", eh.connectionString)
+
+    def test_missing_params_raises(self):
+        # Missing one required param
+        with self.assertRaises(InvalidEventhubHandleParameters):
+            EventhubHandle(
+                namespace="testns",
+                eventhub="testhub",
+                accessKeyName="testkey",
+                # Missing accessKey
+            )
+
+    def test_connection_str_overrides_namespace(self):
+        # In current implementation: if namespace is passed, it takes priority
+        conn_str = (
+            "Endpoint=sb://parsedns.servicebus.windows.net/parsedhub;"
+            "EntityPath=parsedhub;SharedAccessKeyName=testkey;"
+            "SharedAccessKey=secret"
+        )
+        eh = EventhubHandle(
+            connection_str=conn_str,
+            namespace="ignoredns",  # <-- actually used
+        )
+
+        self.assertEqual(eh.bootstrap_servers, "ignoredns.servicebus.windows.net:9093")
+        self.assertEqual(eh.topic, "parsedhub")  # this still comes from conn string
+
+    def test_entity_path_from_connection_string(self):
+        # No eventhub argument → should be parsed from conn_str
+        conn_str = (
+            "Endpoint=sb://ns1.servicebus.windows.net/eh1;"
+            "EntityPath=eh1;SharedAccessKeyName=testkey;SharedAccessKey=secret"
+        )
+
+        handle = EventhubHandle(connection_str=conn_str)
+
+        self.assertEqual(handle.topic, "eh1")
+
+    def test_entity_path_from_argument(self):
+        # eventhub argument provided → should override EntityPath from conn_str
+        conn_str = (
+            "Endpoint=sb://ns1.servicebus.windows.net/eh1;"
+            "EntityPath=eh1;SharedAccessKeyName=testkey;SharedAccessKey=secret"
+        )
+
+        handle = EventhubHandle(connection_str=conn_str, eventhub="override_eh")
+
+        self.assertEqual(handle.topic, "override_eh")
+
+    def test_entity_path_with_manual_fields_only(self):
+        handle = EventhubHandle(
+            namespace="ns2", eventhub="eh2", accessKeyName="key", accessKey="secret"
+        )
+
+        self.assertEqual(handle.topic, "eh2")
+
+    def test_missing_entity_path_and_eventhub_raises(self):
+        # Valid conn_str but missing EntityPath → should raise KeyError
+        conn_str = (
+            "Endpoint=sb://ns.servicebus.windows.net/;"  # No EntityPath!
+            "SharedAccessKeyName=key;SharedAccessKey=secret"
+        )
+
+        with self.assertRaises(KeyError):
+            EventhubHandle(connection_str=conn_str)

--- a/tests/local/transformers/test_simple_eh_handle_write_transformer.py
+++ b/tests/local/transformers/test_simple_eh_handle_write_transformer.py
@@ -1,0 +1,39 @@
+import pyspark.sql.types as T
+from spetlrtools.testing import DataframeTestCase
+
+from spetlr.etl.transformers import SimpleEventhubHandleTransformer
+from spetlr.spark import Spark
+
+
+class TestSimpleEventhubHandleTransformer(DataframeTestCase):
+    def test_01_basic_transformation(self):
+        input_schema = T.StructType(
+            [
+                T.StructField("id", T.StringType(), True),
+                T.StructField("amount", T.IntegerType(), True),
+            ]
+        )
+
+        input_data = [
+            ("a1", 100),
+            ("b2", 200),
+        ]
+
+        df_input = Spark.get().createDataFrame(data=input_data, schema=input_schema)
+
+        df_transformed = SimpleEventhubHandleTransformer().process(df_input)
+
+        expected_data = [('{"id":"a1","amount":100}',), ('{"id":"b2","amount":200}',)]
+
+        expected_schema = T.StructType(
+            [
+                T.StructField("value", T.StringType(), True),
+            ]
+        )
+
+        df_expected = Spark.get().createDataFrame(
+            data=expected_data, schema=expected_schema
+        )
+
+        self.assertEqualSchema(df_transformed.schema, df_expected.schema)
+        self.assertDataframeMatches(df_transformed, None, expected_data)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- (Refactor)
- Feature

## Description

### Overview
This PR introduces an eventhubhandle

### What is the current behavior?
Currently, we have differenct eventhub related classes. Here among `eventhubstreamextractor`. which have been inspiration for some of the eventhandle code.

But, in our current setup, we do not provide a handle like the Delta and Sql. This PR introduces a full handle class for eventhub!

### What is the new behavior?
The `EventhubHandle` inherits all the TableHandle methods, and give the possibility to `.read()`, `.append()`, `.overwrite()`, `.read_stream()` and use the handle in the StreamLoader(handle=EventhubHandle) for microbatch stream writes.

