### PR TITLE
Add timeout_power_bi_in_seconds to PowerBi refresh

### DIFF
--- a/docs/power_bi/README.md
+++ b/docs/power_bi/README.md
@@ -248,6 +248,9 @@ The start_refresh() method starts a new refresh of the given PowerBI
 dataset asynchronously. To verify if the refresh succeeded, you need to
 call the check() method after waiting some sufficiently long time
 (e.g. from a separate monitoring job). 
+With the optional "timeout_power_bi_in_seconds" you can specify a
+time-out in seconds inside PowerBI. If the time-out is exceeded,
+PowerBI will interrupt refreshing and return a time-out error.
 
 If you want to refresh only selected tables in the dataset, you can
 specify the optional "table_names" parameter with a list of table names.
@@ -316,9 +319,12 @@ True
 
 The refresh() method starts a new refresh of the given PowerBI dataset
 synchronously. It waits until the refresh is finished or until a time-out
-occurs. The time-out can be specified using the optional "timeout_in_seconds"
+occurs. The time-out can be specified using the "timeout_in_seconds"
 parameter (default is 15 minutes). 
 If the refresh fails or a time-out occurs, the method casts an exception.
+With the optional "timeout_power_bi_in_seconds" you can specify a similar
+time-out in seconds but inside PowerBI. If the time-out is exceeded,
+PowerBI will interrupt refreshing and return a time-out error.
 
 The wait time between calls to the PowerBI API is synchronized with the
 average execution time of previous dataset refreshes via API (only calls
@@ -378,6 +384,7 @@ PowerBi(client,
         workspace_name="Finance",
         dataset_name="Invoicing",
         timeout_in_seconds=10*60,
+        timeout_power_bi_in_seconds=10*60,
         number_of_retries=2,
         local_timezone_name="Europe/Copenhagen").refresh()
 
@@ -386,6 +393,7 @@ PowerBi(client,
         workspace_id="614850c2-3a5c-4d2d-bcaa-d3f20f32a2e0",
         dataset_id="b1f0a07e-e348-402c-a2b2-11f3e31181ce",
         timeout_in_seconds=10*60,
+        timeout_power_bi_in_seconds=10*60,
         number_of_retries=2,
         local_timezone_name="Europe/Copenhagen").refresh()
 ```

--- a/tests/local/power_bi/test_power_bi.py
+++ b/tests/local/power_bi/test_power_bi.py
@@ -1302,7 +1302,26 @@ class TestPowerBi(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertTrue("objects" in result)
         self.assertFalse("retryCount" in result)
+        self.assertFalse("timeout" in result)
         self.assertEqual(expected_result, result["objects"])
+
+    def test_get_refresh_argument_json_with_power_bi_timeout(self):
+        # Arrange
+        sut = PowerBi(
+            PowerBiClient(),
+            workspace_id="614850c2-3a5c-4d2d-bcaa-d3f20f32a2e0",
+            dataset_id="b1f0a07e-e348-402c-a2b2-11f3e31181ce",
+            timeout_power_bi_in_seconds=(5 * 60 * 60 - 5),
+        )
+        expected_result = "04:59:55"
+
+        # Act
+        result = sut._get_refresh_argument_json(with_wait=False)
+
+        # Assert
+        self.assertIsNotNone(result)
+        self.assertTrue("timeout" in result)
+        self.assertEqual(expected_result, result["timeout"])
 
     @patch("requests.post")
     def test_trigger_new_refresh_success(self, mock_post):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- Feature

## Description
PowerBi class constructor has a new parameter "timeout_power_bi_in_seconds".

### Overview
With the optional "timeout_power_bi_in_seconds" you can specify a
time-out in seconds inside PowerBI. If the time-out is exceeded,
PowerBI will interrupt refreshing and return a time-out error.

Additionally, the HTTP 400 Bad request exception is ignored for using DAX queries, if the user did not specifically ask for reading tables via DAX. Microsoft was still working for a solution at the time of making this PR:
https://community.fabric.microsoft.com/t5/Service/DAX-Info-Functions-Against-Published-Datasets/m-p/4374246

### What is the current behavior?
It is not possible to trigger a time-out in PowerBI.

### What is the new behavior?
An optional parameter has been added.

### Does this PR introduce a breaking change?
No. Default value for the new parameter is None.