### PR TITLE
feat: add comment on UC access mode

### DIFF
--- a/src/spetlr/reporting/JobReflection.py
+++ b/src/spetlr/reporting/JobReflection.py
@@ -11,6 +11,15 @@ from spetlr.functions import init_dbutils
 
 
 class JobReflection:
+    """
+
+    NB - Unity Catalog:
+    Interactive Clusters in Shared Access Mode have issues
+    calling this class. Consider using Personal Access Mode if called
+    from interactive sessions.
+
+    """
+
     @classmethod
     @lru_cache
     def get_job_details(cls) -> Dict:

--- a/src/spetlr/reporting/SlackNotifier.py
+++ b/src/spetlr/reporting/SlackNotifier.py
@@ -14,6 +14,11 @@ from .JobReflection import JobReflection
 class SlackNotifier:
     """Send exceptions and notifications to slack webhooks
     while including stacktraces and links back to the job results.
+
+    NB - Unity Catalog:
+    Interactive Clusters in Shared Access Mode have issues
+    calling this class. Consider using Personal Access Mode if called
+    from interactive sessions.
     """
 
     def __init__(self, *webhookurl: str):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Documentation Update

## Description

### Overview
The SlackNotifier has issues using Shared Clusters access mode when UC is activated

This PR adds a comment for users. 