### PR TITLE
Prevent collecting row to python

### DIFF
--- a/src/spetlr/delta/delta_handle.py
+++ b/src/spetlr/delta/delta_handle.py
@@ -251,7 +251,7 @@ class DeltaHandle(TableHandle):
         df_target = self.read()
 
         # If the target is empty, always do faster full load
-        if len(df_target.take(1)) == 0:
+        if df_target.limit(1).count() == 0:
             return self.write_or_append(df, mode="overwrite")
 
         # Find records that need to be updated in the target (happens seldom)

--- a/src/spetlr/sql/SqlServer.py
+++ b/src/spetlr/sql/SqlServer.py
@@ -259,7 +259,7 @@ class SqlServer(SqlBaseServer):
         if overwrite_if_target_is_empty:
             df_target = self.read_table_by_name(table_name=table_name)
 
-            if len(df_target.take(1)) == 0:
+            if df_target.limit(1).count() == 0:
                 return self.write_table_by_name(
                     df_source=df_source,
                     table_name=table_name,

--- a/src/spetlr/transformations.py
+++ b/src/spetlr/transformations.py
@@ -276,7 +276,7 @@ def merge_df_into_target(
     df_target = Spark.get().table(target_table_name)
 
     # If the target is empty, always do faster full load
-    if len(df_target.take(1)) == 0:
+    if df_target.limit(1).count() == 0:
         return (
             df.write.format(table_format)
             .mode("overwrite")
@@ -322,7 +322,7 @@ def merge_df_into_target(
     )
 
     # If merge is not required, the data can just be appended
-    merge_required = len(df.filter(~F.col("is_new")).take(1)) > 0
+    merge_required = df.filter(~F.col("is_new")).limit(1).count() > 0
     df = df.drop("is_new")
 
     if not merge_required:

--- a/src/spetlr/utils/CheckDfMerge.py
+++ b/src/spetlr/utils/CheckDfMerge.py
@@ -55,7 +55,7 @@ def CheckDfMerge(
     # False if only inserts
     # note: inserts alone happen almost always and can use "append",
     # which is much faster than merge
-    merge_required = len(df.filter(~f.col("is_new")).take(1)) > 0
+    merge_required = df.filter(~f.col("is_new")).limit(1).count() > 0
     df = df.drop("is_new")
 
     return df, merge_required


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Optimization

## Description

There are data objects, such as the date "0001-01-01" which are valid spark values but fail when converting into python.
Using a take(1) to check if there are any rows makes us encounter this error, even though we did not care about the result of the conversion.

We could also just .count() with no limit but that could perhaps perform worse.
