### PR TITLE
Show Slack message headers in one line instead of two

### DIFF
--- a/src/spetlr/reporting/SlackNotifier.py
+++ b/src/spetlr/reporting/SlackNotifier.py
@@ -70,15 +70,14 @@ class SlackNotifier:
         """
         called_from = "".join(traceback.format_stack()[:-_stack_skip])
         try:
-            job_name = JobReflection.get_job_name()
-            text = f"*A message was sent from your job {job_name}*\n"
+            job_name = "your job " + JobReflection.get_job_name()
         except NoRunId:
-            text = "*A message was sent from databricks*\n"
+            job_name = "Databricks"
 
-        text += f"\nSent {self._slack_now()}"
+        text = f"*A message was sent {self._slack_now()} from {job_name}"
         if _source:
-            text += f" from {_source}"
-        text += "\n"
+            text += f" in {_source}"
+        text += "*\n"
 
         if message:
             text += f"\n{message}\n"

--- a/tests/local/reporting/test_slack_reporting.py
+++ b/tests/local/reporting/test_slack_reporting.py
@@ -54,7 +54,8 @@ class SlackNotifierTests(unittest.TestCase):
         self.assertTrue(self.HTTPHandler.called)
         self.assertIn("text", self.HTTPHandler.called_data)
         self.assertRegex(
-            self.HTTPHandler.called_data["text"], "message was sent from databricks"
+            self.HTTPHandler.called_data["text"],
+            "A message was sent .* from Databricks",
         )
         self.assertRegex(self.HTTPHandler.called_data["text"], "my nice message")
         print(self.HTTPHandler.called_data["text"])
@@ -67,7 +68,8 @@ class SlackNotifierTests(unittest.TestCase):
         self.assertTrue(self.HTTPHandler.called)
         self.assertIn("text", self.HTTPHandler.called_data)
         self.assertRegex(
-            self.HTTPHandler.called_data["text"], "message was sent from databricks"
+            self.HTTPHandler.called_data["text"],
+            "A message was sent .* from Databricks",
         )
         self.assertRegex(
             self.HTTPHandler.called_data["text"], "test_02_notify_info_webhook"


### PR DESCRIPTION
## What type of PR is this?
- Optimization

### Overview
When sending Slack messages the message header with the job name, the time and the message source is shown in one line instead of two lines.

### What is the current behavior?
Two separate header lines are shown.

### What is the new behavior?
One combined message header is shown.

### Does this PR introduce a breaking change?
No.