### PR TITLE
feat: change pdate to datetype

### DIFF
--- a/docs/orchestrators/README.md
+++ b/docs/orchestrators/README.md
@@ -17,7 +17,7 @@ The arguments to this orchestrator consist of
 All important configurations follow from the schema and partitioning of the delta table.
 - The delta table must use one of the following partitioning sets
   - either "y,m,d" or "y,m,d,h" whichever is used in the eventhub capture
-  - or "pdate" which is the timestamp, constructed from "ymd" or "ymdh"
+  - or "pdate" which is the date, constructed from "ymd" or "ymdh"
   The capture files will be read from the latest partition in delta and forward, 
     only. (The latest partition will be truncated and re-read to ensure complete but 
     non-overlapping reads.) This incremental approach ensures efficiency.
@@ -74,6 +74,7 @@ The bronze schema should "at least" contain the following schema. The columns of
 
 ```python
 from pyspark.sql.types import (
+    DateType,
     LongType,
     StringType,
     StructField,
@@ -92,7 +93,7 @@ schema_bronze = StructType(
             StructField("Offset", StringType(), True),
             StructField("SystemProperties", StringType(), True),
             StructField("Properties", StringType(), True),
-            StructField("pdate", TimestampType(), True),
+            StructField("pdate", DateType(), True),
         ]
     )
 

--- a/src/spetlr/eh/EventHubCapture.py
+++ b/src/spetlr/eh/EventHubCapture.py
@@ -223,6 +223,6 @@ class EventHubCapture:
                     'make_timestamp(y,m,d,h,0,0,"UTC")'
                     if "h" in self.partitioning
                     else 'make_timestamp(y,m,d,0,0,0,"UTC")'
-                ),
+                ).cast("date"),
             )
         )

--- a/src/spetlr/eh/EventHubCaptureExtractor.py
+++ b/src/spetlr/eh/EventHubCaptureExtractor.py
@@ -76,7 +76,7 @@ class EventHubCaptureExtractor:
                 "make_timestamp(y,m,d,"
                 + ("h," if "h" in self.partitioning else "0,")
                 + '0,0,"UTC")'
-            ),
+            ).cast("date"),
         )
         df = df.drop("_parts")
 

--- a/src/spetlr/orchestrators/eh2bronze/EhToDeltaBronzeTransformer.py
+++ b/src/spetlr/orchestrators/eh2bronze/EhToDeltaBronzeTransformer.py
@@ -104,7 +104,7 @@ class EhToDeltaBronzeTransformer(Transformer):
             f.col("Offset").cast("string").alias("Offset"),
             f.col("SystemProperties").cast("string").alias("SystemProperties"),
             f.col("Properties").cast("string").alias("Properties"),
-            f.col("pdate").cast("timestamp").alias("pdate"),
+            f.col("pdate").cast("date").alias("pdate"),
         )
 
         # Ensure that cols are selected correctly

--- a/tests/cluster/eh/test_eh_json_transformer.py
+++ b/tests/cluster/eh/test_eh_json_transformer.py
@@ -1,6 +1,12 @@
 import json
 
-from pyspark.sql.types import BinaryType, StructField, StructType, TimestampType
+from pyspark.sql.types import (
+    BinaryType,
+    StructField,
+    StructType,
+    TimestampType,
+    DateType,
+)
 from spetlrtools.testing import DataframeTestCase
 from spetlrtools.time import dt_utc
 
@@ -17,7 +23,7 @@ class JsonEhTransformerUnitTests(DataframeTestCase):
     capture_eventhub_output_schema = StructType(
         [
             StructField("Body", BinaryType(), True),
-            StructField("pdate", TimestampType(), True),
+            StructField("pdate", DateType(), True),
             StructField("EnqueuedTimestamp", TimestampType(), True),
         ]
     )

--- a/tests/local/eh/test_ehto_bronze_and_silver.py
+++ b/tests/local/eh/test_ehto_bronze_and_silver.py
@@ -8,6 +8,7 @@ from pyspark.sql.types import (
     StructField,
     StructType,
     TimestampType,
+    DateType,
 )
 from spetlrtools.testing import DataframeTestCase
 from spetlrtools.testing.TestHandle import TestHandle
@@ -41,7 +42,7 @@ class EhtoBronzeAndSilverUnitTests(DataframeTestCase):
             StructField("Offset", StringType(), True),
             StructField("SystemProperties", StringType(), True),
             StructField("Properties", StringType(), True),
-            StructField("pdate", TimestampType(), True),
+            StructField("pdate", DateType(), True),
         ]
     )
 
@@ -62,7 +63,7 @@ class EhtoBronzeAndSilverUnitTests(DataframeTestCase):
         [
             StructField("Id", StringType(), True),
             StructField("EnqueuedTimestamp", TimestampType(), True),
-            StructField("pdate", TimestampType(), True),
+            StructField("pdate", DateType(), True),
         ]
     )
 
@@ -75,7 +76,7 @@ class EhtoBronzeAndSilverUnitTests(DataframeTestCase):
             StructField("SystemProperties", StringType(), True),
             StructField("Properties", StringType(), True),
             StructField("Body", BinaryType(), True),
-            StructField("pdate", TimestampType(), True),
+            StructField("pdate", DateType(), True),
             StructField("EnqueuedTimestamp", TimestampType(), True),
         ]
     )

--- a/tests/local/eh/test_ehtodeltabronze_transformer.py
+++ b/tests/local/eh/test_ehtodeltabronze_transformer.py
@@ -8,6 +8,7 @@ from pyspark.sql.types import (
     StructField,
     StructType,
     TimestampType,
+    DateType,
 )
 from spetlrtools.testing import DataframeTestCase
 from spetlrtools.testing.TestHandle import TestHandle
@@ -32,7 +33,7 @@ class EhtoDeltaTransformerUnitTests(DataframeTestCase):
             StructField("Offset", StringType(), True),
             StructField("SystemProperties", StringType(), True),
             StructField("Properties", StringType(), True),
-            StructField("pdate", TimestampType(), True),
+            StructField("pdate", DateType(), True),
         ]
     )
 
@@ -56,7 +57,7 @@ class EhtoDeltaTransformerUnitTests(DataframeTestCase):
             StructField("SystemProperties", StringType(), True),
             StructField("Properties", StringType(), True),
             StructField("Body", BinaryType(), True),
-            StructField("pdate", TimestampType(), True),
+            StructField("pdate", DateType(), True),
             StructField("EnqueuedTimestamp", TimestampType(), True),
         ]
     )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Refactor
- Bug Fix


## Description

### Overview
The `EventHubCaptureExtractor` generates a partion date from the capture file path called `pdate`.
This date is currently saved as a timestamptype, which I find very odd, since it refers to a datetype.

Looking into the patitions of the folders, the partition folders actually only have one folder per date, but the format is odd, since it is the timestamp name (with 00:00) on. 

### What is the current behavior?
Today `pdate` is a timestamptype

### What is the new behavior?
`pdate` become a date

### Does this PR introduce a breaking change?
Yes! 

The type of the `pdate` changes. If you extract hours, minutes, seconds etc from the column - this would break.
Also your tables should have updated their type from timestamptype to datetype. 

Writing data into the tables from datetime into timestamptype may break. 
