### PR TITLE
fix: json options in ehjsontodeltatransformer (+ black formatting)

### DIFF
--- a/src/spetlr/cache/CachedLoader.py
+++ b/src/spetlr/cache/CachedLoader.py
@@ -327,8 +327,7 @@ class CachedLoader(Loader):
 
         (df.select(*p.key_cols).createOrReplaceTempView("provisionalMarkupKeys"))
         other_cols = [p.deletedTime] + p.cache_id_cols
-        spark.sql(
-            f"""
+        spark.sql(f"""
                 MERGE INTO {p.cache_table_name} AS c
                 USING provisionalMarkupKeys AS p
                 ON  {' AND '.join(
@@ -343,8 +342,7 @@ class CachedLoader(Loader):
                     VALUES ( {', '.join(f'p.{c}' for c in p.key_cols)},
                             0, current_timestamp(),
                             {', '.join('NULL' for _ in other_cols)})
-            """
-        )
+            """)
         return pre_version
 
     @_retry_cache

--- a/src/spetlr/eh/EventHubCapture.py
+++ b/src/spetlr/eh/EventHubCapture.py
@@ -84,16 +84,14 @@ class EventHubCapture:
                 {"name": "Body", "type": "string"},
             ],
         }
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
             CREATE TABLE {self.name}
             ({", ".join(f"{c} STRING" for c in self.partitioning)})
             STORED AS AVRO
             PARTITIONED BY ({",".join(self.partitioning)})
             LOCATION "{self.path}"
             TBLPROPERTIES ('avro.schema.literal'='{json.dumps(avro_schema)}');
-        """
-        )
+        """)
 
     def _discover_first_partition(self) -> PartitionSpec:
         """Add the first partition by discovering it from filesystem."""

--- a/src/spetlr/etl/extractors/check_schema_extractor.py
+++ b/src/spetlr/etl/extractors/check_schema_extractor.py
@@ -26,11 +26,9 @@ class CheckSchemaExtractor(Extractor):
         self.handle.set_schema(expected_schema)
 
         if not data_schema.__eq__(expected_schema):
-            raise SchemasNotEqualException(
-                f"""Schemas have different number of columns.
+            raise SchemasNotEqualException(f"""Schemas have different number of columns.
                 Data schema:
                 {data_schema.json()}
                 Expected schema:
                 {expected_schema.json()}
-                """
-            )
+                """)

--- a/src/spetlr/orchestrators/ehjson2delta/EhJsonToDeltaTransformer.py
+++ b/src/spetlr/orchestrators/ehjson2delta/EhJsonToDeltaTransformer.py
@@ -49,7 +49,9 @@ class EhJsonToDeltaTransformer(Transformer):
             else:
                 df = df.select(*direct_cols)
         else:
-            json_options = {"readerCaseSensitive": self.case_sensitive}
+            json_options = {}
+            if not self.case_sensitive:
+                json_options["readerCaseSensitive"] = False
 
             # every column that is in the target delta table and that is not a direct
             # column from the source eventhub DataFrame, is assumed to be a column whose
@@ -60,10 +62,12 @@ class EhJsonToDeltaTransformer(Transformer):
                 if col not in source_df.columns and col != "BodyJson"
             ]
             body_schema = target_df.select(*body_cols).schema
+
+            from_json_kwargs = {"options": json_options} if json_options else {}
             df = df.withColumn(
                 "Body",
                 f.from_json(
-                    f.decode("Body", "utf-8"), body_schema, options=json_options
+                    f.decode("Body", "utf-8"), body_schema, **from_json_kwargs
                 ).alias("Body"),
             )
             if _keep_body_as_json:

--- a/src/spetlr/orchestrators/ehjson2delta/EhJsonToDeltaTransformer.py
+++ b/src/spetlr/orchestrators/ehjson2delta/EhJsonToDeltaTransformer.py
@@ -49,9 +49,10 @@ class EhJsonToDeltaTransformer(Transformer):
             else:
                 df = df.select(*direct_cols)
         else:
-            json_options = {}
-            if not self.case_sensitive:
-                json_options["readerCaseSensitive"] = False
+            if self.case_sensitive:
+                json_options = {"readerCaseSensitive": "true"}
+            else:
+                json_options = {"readerCaseSensitive": "false"}
 
             # every column that is in the target delta table and that is not a direct
             # column from the source eventhub DataFrame, is assumed to be a column whose

--- a/src/spetlr/reporting/SlackNotifier.py
+++ b/src/spetlr/reporting/SlackNotifier.py
@@ -114,15 +114,13 @@ class SlackNotifier:
             )
 
         text = f"*An exception occurred in {self._get_job_description()}*\n"
-        text += dedent(
-            f"""The error occurred at {self._slack_now()}
+        text += dedent(f"""The error occurred at {self._slack_now()}
 
         Traceback:
         ```
         {traceback.format_exc()}
         ```
-        """
-        )
+        """)
 
         self._add_link_and_publish(text)
 

--- a/src/spetlr/sql/SqlServer.py
+++ b/src/spetlr/sql/SqlServer.py
@@ -275,12 +275,10 @@ class SqlServer(SqlBaseServer):
 
         with self.connect_to_db() as conn:
             # Create temp staging table for merge based source table
-            conn.execute(
-                f"""
+            conn.execute(f"""
                 SELECT * INTO {staging_table_name}
                 FROM {table_name} WHERE 1 = 0;
-                """
-            )
+                """)
 
             self.write_table_by_name(
                 df_source=df_source,
@@ -306,24 +304,20 @@ class SqlServer(SqlBaseServer):
         self.execute_sql(f"TRUNCATE TABLE {table_name}")
 
     def drop_table_by_name(self, table_name: str):
-        self.execute_sql(
-            f"""
+        self.execute_sql(f"""
                 IF OBJECT_ID('{table_name}', 'U') IS NOT NULL
                 BEGIN
                   DROP TABLE {table_name}
                 END
-            """
-        )
+            """)
 
     def drop_view_by_name(self, table_name: str):
-        self.execute_sql(
-            f"""
+        self.execute_sql(f"""
                 IF OBJECT_ID('{table_name}', 'V') IS NOT NULL
                 BEGIN
                     DROP view {table_name}
                 END
-            """
-        )
+            """)
 
     def test_odbc_connection(self):
         """

--- a/tests/cluster/cache/test_cache.py
+++ b/tests/cluster/cache/test_cache.py
@@ -121,8 +121,7 @@ class CachedLoaderTests(unittest.TestCase):
         )
         DbHandle.from_tc("TestDb").create()
         spark = Spark.get()
-        spark.sql(
-            """
+        spark.sql("""
             CREATE TABLE IF NOT EXISTS {CachedTest_name}
             (
                 a STRING,
@@ -134,13 +133,9 @@ class CachedLoaderTests(unittest.TestCase):
             )
             USING DELTA
             COMMENT "Caching Test"
-        """.format(
-                **tc.get_all_details()
-            )
-        )
+        """.format(**tc.get_all_details()))
 
-        spark.sql(
-            """
+        spark.sql("""
             CREATE TABLE IF NOT EXISTS {CachedTestTarget_name}
             (
                 a STRING,
@@ -149,10 +144,7 @@ class CachedLoaderTests(unittest.TestCase):
             )
             USING DELTA
             COMMENT "Caching target"
-        """.format(
-                **tc.get_all_details()
-            )
-        )
+        """.format(**tc.get_all_details()))
 
         cls.params = CachedLoaderParameters(
             cache_table_name=tc.table_name("CachedTest"),

--- a/tests/cluster/cache/test_cache_fail_sequence.py
+++ b/tests/cluster/cache/test_cache_fail_sequence.py
@@ -29,15 +29,13 @@ class ChildCacher(CachedLoader):
         target_name = Configurator().table_name("CachedTestTarget")
 
         df.createOrReplaceTempView("to_be_deleted")
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
             MERGE INTO {target_name} AS t
             USING to_be_deleted AS d
             ON t.a==d.a
             WHEN MATCHED
             THEN DELETE
-        """
-        )
+        """)
         if self.fail_delete:
             raise TestError("intended fail point")
         return df
@@ -63,8 +61,7 @@ class CachedLoaderProvisionalMarkupTests(unittest.TestCase):
         )
         DbHandle.from_tc("TestDb").create()
         spark = Spark.get()
-        spark.sql(
-            """
+        spark.sql("""
             CREATE TABLE IF NOT EXISTS {CachedTest_name}
             (
                 a STRING,
@@ -72,22 +69,15 @@ class CachedLoaderProvisionalMarkupTests(unittest.TestCase):
                 loadedTime TIMESTAMP,
                 deletedTime TIMESTAMP
             )
-        """.format(
-                **tc.get_all_details()
-            )
-        )
+        """.format(**tc.get_all_details()))
 
-        spark.sql(
-            """
+        spark.sql("""
             CREATE TABLE IF NOT EXISTS {CachedTestTarget_name}
             (
                 a STRING,
                 payload STRING
             )
-        """.format(
-                **tc.get_all_details()
-            )
-        )
+        """.format(**tc.get_all_details()))
 
         cls.params = CachedLoaderParameters(
             cache_table_name=tc.table_name("CachedTest"),

--- a/tests/cluster/delta/test_delta_class.py
+++ b/tests/cluster/delta/test_delta_class.py
@@ -162,8 +162,7 @@ class DeltaTests(DataframeTestCase):
 
     def test_09_partitioning(self):
         dh = DeltaHandle.from_tc("MyTbl4")
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
             CREATE TABLE {dh.get_tablename()}
             (
             colA string,
@@ -171,29 +170,25 @@ class DeltaTests(DataframeTestCase):
             payload string
             )
             PARTITIONED BY (colB,colA)
-        """
-        )
+        """)
 
         self.assertEqual(dh.get_partitioning(), ["colB", "colA"])
 
         dh2 = DeltaHandle.from_tc("MyTbl5")
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
             CREATE TABLE {dh2.get_tablename()}
             (
             colA string,
             colB int,
             payload string
             )
-        """
-        )
+        """)
 
         self.assertEqual(dh2.get_partitioning(), [])
 
     def test_10_cluster(self):
         dh = DeltaHandle.from_tc("MyTbl6")
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
             CREATE TABLE {dh.get_tablename()}
             (
             colA string,
@@ -201,22 +196,19 @@ class DeltaTests(DataframeTestCase):
             payload string
             )
             CLUSTER BY (colB,colA)
-        """
-        )
+        """)
 
         self.assertEqual(dh.get_cluster(), ["colB", "colA"])
 
         dh2 = DeltaHandle.from_tc("MyTbl7")
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
             CREATE TABLE {dh2.get_tablename()}
             (
             colA string,
             colB int,
             payload string
             )
-        """
-        )
+        """)
 
         self.assertEqual(dh2.get_cluster(), [])
 

--- a/tests/cluster/delta/test_delta_stream.py
+++ b/tests/cluster/delta/test_delta_stream.py
@@ -226,12 +226,10 @@ class DeltaStreamTests(unittest.TestCase):
 
     def _create_tbl_mirror(self):
         dh = DeltaHandle.from_tc("MyTblMirror")
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
                             CREATE TABLE {dh.get_tablename()}
                             (
                             id int,
                             name string
                             )
-                        """
-        )
+                        """)

--- a/tests/cluster/delta/test_filehandle.py
+++ b/tests/cluster/delta/test_filehandle.py
@@ -94,8 +94,7 @@ class FileHandleTests(unittest.TestCase):
         DbHandle.from_tc("MyDb").create()
 
         dh_sink = DeltaHandle.from_tc("AvroSink")
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
                             CREATE TABLE {dh_sink.get_tablename()}
                             (
                             id int,
@@ -104,8 +103,7 @@ class FileHandleTests(unittest.TestCase):
                             )
                             USING DELTA
                             LOCATION '{tc.get("AvroSink","path")}'
-                        """
-        )
+                        """)
 
         self._add_avro_data_to_source([(1, "a", "None"), (2, "b", "None")])
 
@@ -151,8 +149,7 @@ class FileHandleTests(unittest.TestCase):
 
     def _create_tbl_mirror(self):
         dh = DeltaHandle.from_tc("MyTblMirror")
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
                             CREATE TABLE {dh.get_tablename()}
                             (
                             id int,
@@ -160,8 +157,7 @@ class FileHandleTests(unittest.TestCase):
                             _rescued_data string
                             )
                             LOCATION '{Configurator().get("MyTblMirror","path")}'
-                        """
-        )
+                        """)
 
     def _add_avro_data_to_source(self, input_data: List[Tuple[int, str, str]]):
         df = Spark.get().createDataFrame(

--- a/tests/cluster/eh/test_eh_json_orchestrator.py
+++ b/tests/cluster/eh/test_eh_json_orchestrator.py
@@ -29,27 +29,21 @@ class JsonEhOrchestratorUnitTests(unittest.TestCase):
         spark.sql(f"DROP TABLE IF EXISTS {cls.tc.table_name('TblYMDH')}")
         spark.sql(f"DROP TABLE IF EXISTS {cls.tc.table_name('TblPdate')}")
 
-        spark.sql(
-            f"""
+        spark.sql(f"""
             CREATE TABLE {cls.tc.table_name('TblYMD')}
             (id int, name string, y int, m int, d int)
             PARTITIONED BY (y,m,d)
-        """
-        )
-        spark.sql(
-            f"""
+        """)
+        spark.sql(f"""
             CREATE TABLE {cls.tc.table_name('TblYMDH')}
             (id int, name string, y int, m int, d int, h int)
             PARTITIONED BY (y,m,d,h)
-        """
-        )
-        spark.sql(
-            f"""
+        """)
+        spark.sql(f"""
             CREATE TABLE {cls.tc.table_name('TblPdate')}
             (id int, name string, pdate timestamp)
             PARTITIONED BY (pdate)
-        """
-        )
+        """)
 
     def test_reading_YMD(self):
         dh = DeltaHandle.from_tc("TblYMD")

--- a/tests/cluster/eh/test_eh_json_transformer.py
+++ b/tests/cluster/eh/test_eh_json_transformer.py
@@ -61,39 +61,31 @@ class JsonEhTransformerUnitTests(DataframeTestCase):
         spark.sql(f"DROP TABLE IF EXISTS {cls.tc.table_name('TblPdate3')}")
         spark.sql(f"DROP TABLE IF EXISTS {cls.tc.table_name('TblPdate4')}")
 
-        spark.sql(
-            f"""
+        spark.sql(f"""
                 CREATE TABLE {cls.tc.table_name('TblPdate1')}
                 (id int, name string, BodyJson string, pdate timestamp,
                 EnqueuedTimestamp timestamp)
                 PARTITIONED BY (pdate)
-            """
-        )
+            """)
 
-        spark.sql(
-            f"""
+        spark.sql(f"""
                 CREATE TABLE {cls.tc.table_name('TblPdate2')}
                 (id int, name string, pdate timestamp, EnqueuedTimestamp timestamp)
                 PARTITIONED BY (pdate)
-            """
-        )
+            """)
 
-        spark.sql(
-            f"""
+        spark.sql(f"""
                 CREATE TABLE {cls.tc.table_name('TblPdate3')}
                 (id int, name string, pdate timestamp, EnqueuedTimestamp timestamp,
                 Unknown string)
                 PARTITIONED BY (pdate)
-            """
-        )
+            """)
 
-        spark.sql(
-            f"""
+        spark.sql(f"""
                 CREATE TABLE {cls.tc.table_name('TblPdate4')}
                 (id int, Name string, pdate timestamp, EnqueuedTimestamp timestamp)
                 PARTITIONED BY (pdate)
-            """
-        )
+            """)
 
     def test_01_transformer_w_body(self):
         """Tests whether the body is saved as BodyJson"""

--- a/tests/cluster/eh/test_eh_saving.py
+++ b/tests/cluster/eh/test_eh_saving.py
@@ -81,8 +81,7 @@ class EventHubsTests(unittest.TestCase):
         tc = Configurator()
         tc.set_debug()
         tc.register("CpTblYMD", {"name": "CaptureTableYMD{ID}"})
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
             CREATE TABLE {tc.table_name('CpTblYMD')}
             (
                 id int,
@@ -92,8 +91,7 @@ class EventHubsTests(unittest.TestCase):
                 d int
             )
             PARTITIONED BY (y,m,d)
-        """
-        )
+        """)
 
         eh_orch = EhJsonToDeltaOrchestrator.from_tc("SpetlrEh", "CpTblYMD")
         eh_orch.execute()
@@ -110,8 +108,7 @@ class EventHubsTests(unittest.TestCase):
         # Part 2, pdate partitioned.
 
         tc.register("CpTblDate", {"name": "CaptureTableDate{ID}"})
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
             CREATE TABLE {tc.table_name('CpTblDate')}
             (
                 id INTEGER,
@@ -119,8 +116,7 @@ class EventHubsTests(unittest.TestCase):
                 pdate TIMESTAMP
             )
             PARTITIONED BY (pdate)
-        """
-        )
+        """)
 
         # test the insertion of additional filters
         class IdFilter(Transformer):

--- a/tests/cluster/eh/test_eventhub_handle.py
+++ b/tests/cluster/eh/test_eventhub_handle.py
@@ -10,7 +10,7 @@ from spetlrtools.time import dt_utc
 from spetlr.configurator import Configurator
 from spetlr.delta import DbHandle, DeltaHandle
 from spetlr.eh import EventhubHandle
-from spetlr.etl import Orchestrator, Transformer
+from spetlr.etl import Orchestrator
 from spetlr.etl.extractors.stream_extractor import StreamExtractor
 from spetlr.etl.loaders import SimpleLoader
 from spetlr.etl.loaders.stream_loader import StreamLoader

--- a/tests/cluster/etl/test_upsertloader_streaming.py
+++ b/tests/cluster/etl/test_upsertloader_streaming.py
@@ -113,15 +113,13 @@ class UpsertLoaderTestsDeltaStream(DataframeTestCase):
 
         dh = DeltaHandle.from_tc(tableid)
 
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
             CREATE TABLE IF NOT EXISTS {dh.get_tablename()}
             (
             id int,
             name string
             )
-            """
-        )
+            """)
 
         df_source = DataframeCreator.make_partial(
             self.dummy_schema, self.dummy_columns, data

--- a/tests/cluster/loaders/test_scd2_loader.py
+++ b/tests/cluster/loaders/test_scd2_loader.py
@@ -475,8 +475,7 @@ class TestSCD2Loader(DataframeTestCase):
         # Create a DataFrame from the test data
         df_in = Spark.get().createDataFrame(data=data_start, schema=schema_start)
 
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
                     CREATE TABLE {dh_source.get_tablename()}
                     (
                     Id integer,
@@ -484,11 +483,9 @@ class TestSCD2Loader(DataframeTestCase):
                     Col2 string,
                     TimeCol timestamp
                     )
-                """
-        )
+                """)
 
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
                     CREATE TABLE {dh_sink.get_tablename()}
                     (
                     Id integer,
@@ -500,8 +497,7 @@ class TestSCD2Loader(DataframeTestCase):
                     IsCurrent boolean,
                     HashValue string
                     )
-                """
-        )
+                """)
 
         # Define the columns for joining and time column for the SCD2 process
         _join_cols = ["Id"]
@@ -643,8 +639,7 @@ class TestSCD2Loader(DataframeTestCase):
         dbh.create()
         dh = DeltaHandle.from_tc("MyTbl")
 
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
                     CREATE TABLE {dh.get_tablename()}
                     (
                     Id integer,
@@ -656,8 +651,7 @@ class TestSCD2Loader(DataframeTestCase):
                     IsCurrent boolean,
                     HashValue string
                     )
-                """
-        )
+                """)
 
         """
         First test takes this input data:

--- a/tests/cluster/schema_manager/test_schema_manager.py
+++ b/tests/cluster/schema_manager/test_schema_manager.py
@@ -60,8 +60,7 @@ class TestSchemaManager(DataframeTestCase):
     def test_get_all_spark_sql_schemas(self):
         schemas_dict = SchemaManager().get_all_spark_sql_schemas()
 
-        test_schema1_str = dedent(
-            """\
+        test_schema1_str = dedent("""\
             a int,
               b int COMMENT "really? is that it?",
               c string,
@@ -69,17 +68,14 @@ class TestSchemaManager(DataframeTestCase):
               d timestamp,
               m map<int,string>,
               p decimal(10,3),
-              final string"""
-        )
-        test_schema2_str = dedent(
-            """\
+              final string""")
+        test_schema2_str = dedent("""\
             a int,
               c string,
               d timestamp,
               m map<int,string>,
               p decimal(10,3),
-              final string"""
-        )
+              final string""")
         expected_schemas = {
             "python_test_schema": test_schema1_str,
             "python_test_schema2": test_schema2_str,

--- a/tests/cluster/utils/test_stop_test_stream.py
+++ b/tests/cluster/utils/test_stop_test_stream.py
@@ -55,24 +55,20 @@ class TestStopTestStreamsOnCluster(DataframeTestCase):
         )
 
         dh = DeltaHandle.from_tc("MyTbl")
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
                 CREATE TABLE {dh.get_tablename()}
                 (
                 id int,
                 name string
-                )"""
-        )
+                )""")
 
         dh_mirror = DeltaHandle.from_tc("MyTblMirror")
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
                 CREATE TABLE {dh_mirror.get_tablename()}
                 (
                 id int,
                 name string
-                )"""
-        )
+                )""")
         _query_name = Configurator().get("MyTblMirror", "query_name")
 
         (

--- a/tests/local/configurator/test_configurator.py
+++ b/tests/local/configurator/test_configurator.py
@@ -163,8 +163,7 @@ class TestConfigurator(unittest.TestCase):
         self.assertEqual(len(statements), 3)
         self.assertEqual(
             statements[1],
-            dedent(
-                """\
+            dedent("""\
 
 
                         -- spetlr.Configurator key: MyDetailsTable
@@ -179,8 +178,7 @@ class TestConfigurator(unittest.TestCase):
                         )
                         USING DELTA
                         COMMENT "Dummy Database 1 details"
-                        LOCATION "/mnt/foo/bar/my_db1/details/";"""
-            ),
+                        LOCATION "/mnt/foo/bar/my_db1/details/";"""),
         )
 
     def test_10_generate_new_UUID_debug(self):

--- a/tests/local/configurator/test_configurator_cli.py
+++ b/tests/local/configurator/test_configurator_cli.py
@@ -34,8 +34,7 @@ class TestConfiguratorCli(unittest.TestCase):
             # file written. clean exit
 
             conts = open(name).read()
-            expected = dedent(
-                """\
+            expected = dedent("""\
                 # AUTO GENERATED FILE
                 # contains all spetlr.Configurator keys
 
@@ -46,8 +45,7 @@ class TestConfiguratorCli(unittest.TestCase):
                 MyForked = "MyForked"  # name: first
                 MyRecursing = "MyRecursing"  # name: recursing
                 MySecond = "MySecond"  # name: first
-            """
-            )
+            """)
             self.assertEqual(conts, expected)
 
             # repeat the test

--- a/tests/local/power_bi/test_power_bi.py
+++ b/tests/local/power_bi/test_power_bi.py
@@ -180,7 +180,7 @@ class TestPowerBi(unittest.TestCase):
 
         # Assert
         self.assertIsNotNone(result)
-        assert_frame_equal(expected, result.get_pandas_df())
+        assert_frame_equal(expected, result.get_pandas_df(), check_dtype=False)
 
     @patch("requests.get")
     def test_get_refresh_history_failure(self, mock_get):
@@ -273,7 +273,7 @@ class TestPowerBi(unittest.TestCase):
         # Assert
         self.assertIsNotNone(result)
         assert_frame_equal(
-            expected, result.get_pandas_df()[list(expected.columns.values)]
+            expected, result.get_pandas_df()[list(expected.columns.values)], check_dtype=False
         )
 
     @patch("requests.post")
@@ -468,7 +468,7 @@ class TestPowerBi(unittest.TestCase):
 
         # Assert
         self.assertIsNotNone(result)
-        assert_frame_equal(expected, result.get_pandas_df())
+        assert_frame_equal(expected, result.get_pandas_df(), check_dtype=False)
 
     @patch("requests.get")
     def test_combine_dataframes_on_workspace_level_with_success(self, mock_get):
@@ -702,7 +702,7 @@ class TestPowerBi(unittest.TestCase):
 
         # Assert
         self.assertIsNotNone(result)
-        assert_frame_equal(expected, result.get_pandas_df())
+        assert_frame_equal(expected, result.get_pandas_df(), check_dtype=False)
 
     @patch("requests.get")
     def test_get_last_refresh_success(self, mock_get):

--- a/tests/local/power_bi/test_spark_pandas_dataframe.py
+++ b/tests/local/power_bi/test_spark_pandas_dataframe.py
@@ -104,7 +104,8 @@ class TestSparkPandasDataFrame(unittest.TestCase):
 
         # Assert
         assert_frame_equal(
-            expected.reset_index(drop=True), sut.get_pandas_df().reset_index(drop=True)
+            expected.reset_index(drop=True), sut.get_pandas_df().reset_index(drop=True),
+            check_dtype=False,
         )
 
     def test_parse_time_success(self):

--- a/tests/local/schema_manager/test_schema_manager.py
+++ b/tests/local/schema_manager/test_schema_manager.py
@@ -90,9 +90,7 @@ class TestSchemaManager(unittest.TestCase):
         )
 
     def test_07_parse_comments(self):
-        d_field = get_schema(
-            """
+        d_field = get_schema("""
             d string COMMENT 'Whatsupp with "you"',
-        """
-        ).fields[0]
+        """).fields[0]
         self.assertEqual(d_field.metadata, {"comment": 'Whatsupp with "you"'})

--- a/tests/local/test_get_schema.py
+++ b/tests/local/test_get_schema.py
@@ -8,8 +8,7 @@ from spetlr.schema_manager.spark_schema import get_schema
 
 class TestGetSchema(unittest.TestCase):
     def test_01_schema1(self):
-        sql = dedent(
-            r"""
+        sql = dedent(r"""
             a int NOT
             NULL,
             b int COMMENT "really? is that it?",
@@ -25,8 +24,7 @@ class TestGetSchema(unittest.TestCase):
             p decimal(10,3),
             final string,
             gen DATE GENERATED ALWAYS AS (CAST(d AS DATE))
-            """
-        )
+            """)
         struct = get_schema(sql)
         self.assertEqual(
             t.StructType(

--- a/tests/local/utils/test_dataframe_creation.py
+++ b/tests/local/utils/test_dataframe_creation.py
@@ -10,8 +10,7 @@ class DataframeCreatorTest(unittest.TestCase):
     def setUpClass(cls) -> None:
         Spark.get()
 
-        cls.schema = get_schema(
-            """
+        cls.schema = get_schema("""
             Id INTEGER,
             measured DOUBLE,
             customer STRUCT<
@@ -22,8 +21,7 @@ class DataframeCreatorTest(unittest.TestCase):
                 no:INTEGER,
                 name:STRING
             >>
-        """
-        )
+        """)
 
     def test_full_creation(self):
         df = DataframeCreator.make(

--- a/tests/local/utils/test_mock_etl.py
+++ b/tests/local/utils/test_mock_etl.py
@@ -13,12 +13,10 @@ class MockEtlTest(unittest.TestCase):
     def setUpClass(cls) -> None:
         Spark.get()
 
-        cls.schema = get_schema(
-            """
+        cls.schema = get_schema("""
             Id INTEGER,
             measured DOUBLE
-        """
-        )
+        """)
 
     def test_full_etl(self):
         df = DataframeCreator.make(self.schema, [(1, 3.5)])

--- a/tests/sql/test_sql_streaming.py
+++ b/tests/sql/test_sql_streaming.py
@@ -48,15 +48,13 @@ class SqlServerStreamingTests(unittest.TestCase):
 
         dh = DeltaHandle.from_tc("MyTbl")
 
-        Spark.get().sql(
-            f"""
+        Spark.get().sql(f"""
                CREATE TABLE {dh.get_tablename()}
                (
                testcolumn int
                )
                LOCATION '{Configurator().get("MyTbl", "path")}'
-           """
-        )
+           """)
 
         df = Spark.get().createDataFrame([(1,), (2,)], "testcolumn int")
 


### PR DESCRIPTION
# What type of PR is this? (check all applicable)
Bug Fix
# Description
## Overview
Fix EhJsonToDeltaTransformer to pass string values in from_json() options, ensuring compatibility with PySpark Connect.

## What is the current behavior?
EhJsonToDeltaTransformer passes options={"readerCaseSensitive": True/False} (Python booleans) to from_json(). In PySpark Connect, non-string values in the options dict cause serialization failures because Spark expects MAP<STRING, STRING>.

## What is the new behavior?
The options dict now uses explicit string values ("true" / "false") instead of Python booleans, ensuring correct serialization as MAP<STRING, STRING> in both classic PySpark and PySpark Connect.

## Does this PR introduce a breaking change?
No. The behavior is functionally identical — only the serialization format of the options changes.

## Related Issues (Link to the open issue)
N/A

## Additional information
The fix is in EhJsonToDeltaTransformer.py(lines 52-55). The from_json_kwargs conditional on line 67 is retained but now always evaluates to true since json_options is always non-empty.